### PR TITLE
Use Postgres

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,12 +3,17 @@
 Dockerfile
 docker-compose.yml
 
+# Local environment shouldn't be copied
+.env
+
 # Ignore bundler config.
 /.bundle
 
 # Ignore the default SQLite database.
 /db/*.sqlite3
 /db/*.sqlite3-journal
+# Ignore PG data files
+/db/pg
 
 # Ignore all logfiles and tempfiles.
 /log/*

--- a/.gitignore
+++ b/.gitignore
@@ -4,12 +4,17 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile '~/.gitignore_global'
 
+# Ignore local .env file
+.env
+
 # Ignore bundler config.
 /.bundle
 
 # Ignore the default SQLite database.
 /db/*.sqlite3
 /db/*.sqlite3-journal
+/db/pg/*
+!/db/pg/.keep
 
 # Ignore all logfiles and tempfiles.
 /log/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ruby:2.4.1-alpine
 WORKDIR /srv/app
 
 RUN apk --update --upgrade add curl-dev build-base openssh \
-	tzdata libxml2 libxml2-dev libxslt libxslt-dev sqlite-dev \
+	tzdata libxml2 libxml2-dev libxslt libxslt-dev postgresql-dev \
 	nodejs
 
 # Add Yarn to the mix
@@ -19,6 +19,7 @@ RUN bundle install
 
 COPY package.json /srv/app/
 COPY yarn.lock /srv/app/
+RUN yarn install
 
 COPY . /srv/app/
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,8 @@ end
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.1.1'
-# Use sqlite3 as the database for Active Record
-gem 'sqlite3'
+# Use postgresql as the database for Active Record
+gem 'pg', '~> 0.20'
 # Use Puma as the app server
 gem 'puma', '~> 3.7'
 # Use SCSS for stylesheets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,7 @@ GEM
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
+    pg (0.20.0)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -177,7 +178,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.13)
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.7)
@@ -208,13 +208,13 @@ DEPENDENCIES
   guard-rspec
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
+  pg (~> 0.20)
   puma (~> 3.7)
   rails (~> 5.1.1)
   rspec-rails (~> 3.5)
   sass-rails (~> 5.0)
   spring
   spring-watcher-listen (~> 2.0.0)
-  sqlite3
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,25 +1,29 @@
-# SQLite version 3.x
-#   gem install sqlite3
+# PostgreSQL. Versions 9.1 and up are supported.
 #
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
+# Install the pg driver:
+#   gem install pg
+#
+# Configure Using Gemfile
+# gem 'pg'
 #
 default: &default
-  adapter: sqlite3
+  adapter: postgresql
+  encoding: unicode
+  host: <%= ENV.fetch("POSTGRES_HOST") %>
+  user: <%= ENV.fetch("POSTGRES_USER") %>
+  password: <%= ENV.fetch("POSTGRES_PASSWORD") %>
+  # For details on connection pooling, see Rails configuration guide
+  # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  timeout: 5000
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: tapp_development
 
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: tapp_test
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  # Use DATABASE_URL environment variable

--- a/dev.env.default
+++ b/dev.env.default
@@ -1,0 +1,6 @@
+# Environment variables needed for running this project
+# copy this file to .env in this directory for it to be picked up by docker-compose
+POSTGRES_DB=tapp_development
+POSTGRES_USER=tapp
+POSTGRES_PASSWORD=mysecretpassword
+SECRET_KEY_BASE=9a5caa0076926b61d612734ed8ea565cfc5f6cc6bd00f35cd29eb28ca5cccc3d9e57e0174aa1ec7674cf56347cfe074922a453437fa13858ac125b42cb14791b

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,27 @@ version: '2'
 services:
   rails-app:
     build: .
+    environment:
+      POSTGRES_HOST: postgres
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      SECRET_KEY_BASE: ${SECRET_KEY_BASE}
     volumes:
       - .:/srv/app
     ports:
       - "3000:3000"
     command: >
       ./bin/rails-server-entrypoint -b 0.0.0.0 -p 3000
+
+  postgres:
+    image: postgres:9.6-alpine
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - ./db/pg/data:/var/lib/postgresql/data
 
   webpack-dev-server:
     build: .


### PR DESCRIPTION
Review / apply this after #22.

This PR switches the database used from sqlite to PostgreSQL. Postgres runs in a separate container, as a service named `postgres`. On launch, it uses variables set in `.env` (default version of which is in `dev.env.default`) to automatically create a user (see `POSTGRES_USER`) and database (see `POSTGRES_DB`).

After this PR is applied, you need to:
    1. copy `dev.env.default` to `.env` in the working directory
    2. and rebuild the containers (or launch the system with `docker-compose up --build`).

Postgres container will place its database data files in `pg/db/data`. Remove that directory if you want to reset the database.

Postgres image documentation: https://hub.docker.com/_/postgres/