### PR TITLE
Created API documentation for Course Endpoint

### DIFF
--- a/docs/api/courses.yml
+++ b/docs/api/courses.yml
@@ -13,7 +13,6 @@ paths:
       tags:
       - "courses"
       summary: "Update Course Information"
-      description: ""
       consumes:
       - "formData"
       produces:
@@ -32,7 +31,6 @@ paths:
       tags:
       - "courses"
       summary: "Get Course information"
-      description: ""
       produces:
       - "application/json"
       responses:
@@ -47,12 +45,12 @@ paths:
       tags:
       - "courses"
       summary: "Get Course information"
-      description: ""
       parameters:
       - in: path
         name: code
         type: string
         required: true
+        description: "code for Course table"
       produces:
       - "application/json"
       responses:
@@ -62,6 +60,20 @@ paths:
             type: "array"
             items:
               $ref: "#/definitions/Course"
+    patch:
+      tags:
+      - "courses"
+      summary: "Updates course information base on positions.id"
+      parameters:
+      - in: query
+        name: code
+        type: integer
+        required: true
+        description: "id number of Position table"
+      responses:
+        500:
+          description: "Unable to update course position data"
+
 definitions:
   Course:
     type: "object"

--- a/docs/api/courses.yml
+++ b/docs/api/courses.yml
@@ -22,6 +22,21 @@ paths:
             type: "array"
             items:
               $ref: "#/definitions/Course"
+  /courses/{code}:
+    patch:
+      tags:
+      - "courses"
+      summary: "Updates Course information for Course {code}"
+      parameters:
+      - in: path
+        name: code
+        type: string
+        required: true
+        description: "code for a Course in the Course Table"
+      responses:
+        500:
+          description: "Unable to update course data"
+
   /courses/{code}/positions:
     get:
       tags:

--- a/docs/api/courses.yml
+++ b/docs/api/courses.yml
@@ -9,10 +9,44 @@ tags:
   description: "DCS-TA application"
 paths:
   /courses:
+    get:
+      tags:
+      - "courses"
+      summary: "Get all Course information along with its corresponding Positions"
+      produces:
+      - "application/json"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Course"
+  /courses/{code}/positions:
+    get:
+      tags:
+      - "courses"
+      summary: "Get all Position informatio for Course with {code}"
+      parameters:
+      - in: path
+        name: code
+        type: string
+        required: true
+        description: "code for a Course in the Course Table"
+      produces:
+      - "application/json"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Position"
+  /courses/{code}/positions/{id}:
     post:
       tags:
       - "courses"
-      summary: "Update Course Information"
+      summary: "Update Position information based on Course {code}"
       consumes:
       - "formData"
       produces:
@@ -23,53 +57,25 @@ paths:
         description: "Course descriptions that needs to be updated"
         required: true
         schema:
-          $ref: "#/definitions/Course"
+          $ref: "#/definitions/Position"
       responses:
         405:
           description: "Invalid input"
-    get:
+    patch:
       tags:
       - "courses"
-      summary: "Get Course information"
-      produces:
-      - "application/json"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/Course"
-  /courses/{code}:
-    get:
-      tags:
-      - "courses"
-      summary: "Get Course information"
+      summary: "Updates Position information for Course {code} and Position {id}"
       parameters:
       - in: path
         name: code
         type: string
         required: true
-        description: "code for Course table"
-      produces:
-      - "application/json"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/Course"
-    patch:
-      tags:
-      - "courses"
-      summary: "Updates course information base on positions.id"
-      parameters:
-      - in: query
-        name: code
+        description: "code for a Course in the Course Table"
+      - in: path
+        name: id
         type: integer
         required: true
-        description: "id number of Position table"
+        description: "id number in Position table"
       responses:
         500:
           description: "Unable to update course position data"

--- a/docs/api/courses.yml
+++ b/docs/api/courses.yml
@@ -1,0 +1,110 @@
+swagger: "2.0"
+info:
+  description: "This is API for the course endpoint of the DCS-TA app."
+  version: "1.0.0"
+  title: "DCS-TA app"
+basePath: "/v2"
+tags:
+- name: "dcs-ta"
+  description: "DCS-TA application"
+paths:
+  /course:
+    post:
+      tags:
+      - "courses"
+      summary: "Update Course Information"
+      description: ""
+      operationId: "updateCourse"
+      consumes:
+      - "formData"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "Course descriptions that needs to be updated"
+        required: true
+        schema:
+          $ref: "#/definitions/Course"
+      responses:
+        405:
+          description: "Invalid input"
+    get:
+      tags:
+      - "courses"
+      summary: "Get Course information"
+      description: ""
+      operationId: "getAllCourses"
+      produces:
+      - "application/json"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Course"
+  /course/sidebar:
+    get:
+      tags:
+      - "courses"
+      summary: "Get Course Sidebar information"
+      description: ""
+      operationId: "getCourseSideBar"
+      produces:
+      - "application/json"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/CourseSidebar"
+definitions:
+  Course:
+    type: "object"
+    properties:
+      course_id:
+        type: "string"
+        example: "CSC148H1S"
+      course_name:
+        type: "string"
+        example: "Intro to Comp Prog -  Advance Prep"
+      semester:
+        type: "string"
+        example: "Summer 2017"
+      campus:
+        type: "integer"
+        example: 1
+      instructor:
+        type: "array"
+        items:
+          type: "string"
+        example: ["Instructor 1", "Instructor 2"]
+      positions:
+        type: "integer"
+        example: 2
+      hr_position:
+        type: "integer"
+        example: 54
+      enrollment:
+        type: "integer"
+        example: 1000
+      qualifications:
+        type: "string"
+        example: "Strong knowledge of Python. Enthusiasm for teaching. Strong writing skills. Must already have, or be enrolled in, a computer science degree (or equivalent). Prior experience working as a TA for CSC148 would be an asset. Strong scripting skills an asset."
+      duties:
+        type: "string"
+        example: "Work with next year's CSC148F instructors to update course materials, including implementing small online exercises, activities for lectures and labs, writing and implementing assignments (including any necessary solution and starter code, autotesting, handouts, and marking schemes). Help create the tests and final exam. "
+  CourseSidebar:
+    type: "object"
+    properties:
+      course_id:
+        type: "string"
+        example: "CSC148H1S"
+      assigned:
+        type: "integer"
+        example: 0
+      positions:
+        type: "integer"
+        example: 40

--- a/docs/api/courses.yml
+++ b/docs/api/courses.yml
@@ -8,7 +8,7 @@ tags:
 - name: "dcs-ta"
   description: "DCS-TA application"
 paths:
-  /course:
+  /courses:
     post:
       tags:
       - "courses"
@@ -44,22 +44,6 @@ paths:
             type: "array"
             items:
               $ref: "#/definitions/Course"
-  /course/sidebar:
-    get:
-      tags:
-      - "courses"
-      summary: "Get Course Sidebar information"
-      description: ""
-      operationId: "getCourseSideBar"
-      produces:
-      - "application/json"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/CourseSidebar"
 definitions:
   Course:
     type: "object"
@@ -77,10 +61,8 @@ definitions:
         type: "integer"
         example: 1
       instructor:
-        type: "array"
-        items:
-          type: "string"
-        example: ["Instructor 1", "Instructor 2"]
+        type: "integer"
+        example: 13
       positions:
         type: "integer"
         example: 2
@@ -96,15 +78,3 @@ definitions:
       duties:
         type: "string"
         example: "Work with next year's CSC148F instructors to update course materials, including implementing small online exercises, activities for lectures and labs, writing and implementing assignments (including any necessary solution and starter code, autotesting, handouts, and marking schemes). Help create the tests and final exam. "
-  CourseSidebar:
-    type: "object"
-    properties:
-      course_id:
-        type: "string"
-        example: "CSC148H1S"
-      assigned:
-        type: "integer"
-        example: 0
-      positions:
-        type: "integer"
-        example: 40

--- a/docs/api/courses.yml
+++ b/docs/api/courses.yml
@@ -36,6 +36,8 @@ paths:
       responses:
         500:
           description: "Unable to update course data"
+        204:
+          description: "Update succeeded"
 
   /courses/{code}/positions:
     get:
@@ -94,6 +96,8 @@ paths:
       responses:
         500:
           description: "Unable to update course position data"
+        204:
+          description: "Update succeeded"
 
 definitions:
   Course:

--- a/docs/api/courses.yml
+++ b/docs/api/courses.yml
@@ -14,7 +14,6 @@ paths:
       - "courses"
       summary: "Update Course Information"
       description: ""
-      operationId: "updateCourse"
       consumes:
       - "formData"
       produces:
@@ -34,7 +33,26 @@ paths:
       - "courses"
       summary: "Get Course information"
       description: ""
-      operationId: "getAllCourses"
+      produces:
+      - "application/json"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Course"
+  /courses/{code}:
+    get:
+      tags:
+      - "courses"
+      summary: "Get Course information"
+      description: ""
+      parameters:
+      - in: path
+        name: code
+        type: string
+        required: true
       produces:
       - "application/json"
       responses:
@@ -48,33 +66,64 @@ definitions:
   Course:
     type: "object"
     properties:
-      course_id:
+      code:
         type: "string"
-        example: "CSC148H1S"
-      course_name:
-        type: "string"
-        example: "Intro to Comp Prog -  Advance Prep"
-      semester:
-        type: "string"
-        example: "Summer 2017"
-      campus:
+        example: "CSC108H1S"
+      campus_code:
         type: "integer"
         example: 1
-      instructor:
+      instructor_id:
         type: "integer"
         example: 13
-      positions:
-        type: "integer"
-        example: 2
-      hr_position:
-        type: "integer"
-        example: 54
-      enrollment:
+      course_name:
+        type: "string"
+        example: "Intro to Comp Prog"
+      estimated_enrollment:
         type: "integer"
         example: 1000
-      qualifications:
+      created_at:
         type: "string"
-        example: "Strong knowledge of Python. Enthusiasm for teaching. Strong writing skills. Must already have, or be enrolled in, a computer science degree (or equivalent). Prior experience working as a TA for CSC148 would be an asset. Strong scripting skills an asset."
+        format: "date-time"
+        example: "2017-06-05T14:26:44.808Z"
+      updated_at:
+        type: "string"
+        format: "date-time"
+        example: "2017-06-05T14:26:44.808Z"
+      positions:
+        type: "array"
+        $ref: "#/definitions/Position"
+  Position:
+    type: "object"
+    properties:
+      id:
+        type: "integer"
+        example: 4
+      course_code:
+        type: "string"
+        example: "CSC108H1S"
+      title:
+        type: "string"
+        example: "CSC108H1S - Student-Facing TA"
       duties:
         type: "string"
-        example: "Work with next year's CSC148F instructors to update course materials, including implementing small online exercises, activities for lectures and labs, writing and implementing assignments (including any necessary solution and starter code, autotesting, handouts, and marking schemes). Help create the tests and final exam. "
+        example: "Attend lectures to assist in classroom activities. Prepare for each week by doing online programming activities. Some TAs may hold office hours or monitor discussion forums."
+      qualifications:
+        type: "string"
+        example: "Experience with programming, such as by completing a 200-level CSC course, or by achieving excellent marks in multiple 100-level CSC courses, or equivalent. Experience with Python, at the level of CSC 148 or equivalent. Must be enrolled in or have completed a computer science degree, or equivalent. Must be interested in teaching beginner programmers. Willing to try different approaches when explaining simple concepts. TAs should be available during at least one of the CSC 108 lecture times (MWF10-11, W6-9)."
+      hours:
+        type: "integer"
+        example: 54
+      estimated_count:
+        type: "integer"
+        example: 2
+      estimated_total_hours:
+        type: "integer"
+        example: 100
+      created_at:
+        type: "string"
+        format: "date-time"
+        example: "2017-06-05T14:26:44.808Z"
+      updated_at:
+        type: "string"
+        format: "date-time"
+        example: "2017-06-05T14:26:44.808Z"


### PR DESCRIPTION
- continuation of #29 
- created API documentation for course endpoint
- the following are the available API route for courses:
  * `GET /courses`
  * `PATCH /courses/{code}`
  * `GET /courses/{code}/positions`
  * `POST /courses/positions`
  * `PATCH /course/{code}/positions/{id}`