### PR TITLE
Added Course & Position Endpoints for GET, PATCH

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,0 +1,17 @@
+class CoursesController < ApplicationController
+  protect_from_forgery with: :null_session
+  def index
+    @courses = Course.all.includes(:instructor, :positions)
+    render json: @courses.to_json(include: [:instructor, :positions])
+  end
+
+  def update
+    course = Course.find(params[:code].upcase)
+    course.update_attributes!(course_params)
+  end
+
+  private
+  def course_params
+    params.permit(:estimated_enrolment)
+  end
+end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,12 +1,7 @@
 class CoursesController < ApplicationController
   protect_from_forgery with: :null_session
   def index
-    if params[:code] == nil
-      @courses = Course.all.includes(:instructor, :positions)
-    else
-      condition = {code: params[:code].upcase}
-      @courses = Course.where(condition).includes(:instructor, :positions)
-    end
+    @courses = Course.all.includes(:instructor, :positions)
     render json: @courses.to_json(include: [:instructor, :positions])
   end
 

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,7 +1,12 @@
 class CoursesController < ApplicationController
   protect_from_forgery with: :null_session
   def index
-    @courses = Course.all.includes(:instructor, :positions)
+    if params[:code] == nil
+      @courses = Course.all.includes(:instructor, :positions)
+    else
+      condition = {code: params[:code].upcase}
+      @courses = Course.where(condition).includes(:instructor, :positions)
+    end
     render json: @courses.to_json(include: [:instructor, :positions])
   end
 

--- a/app/controllers/positions_controller.rb
+++ b/app/controllers/positions_controller.rb
@@ -1,0 +1,22 @@
+class PositionsController < ApplicationController
+  protect_from_forgery with: :null_session
+
+  def index
+    condition = {course_code: params[:course_code].upcase}
+    @course_positions = Position.where(condition)
+    render json: @course_positions.to_json()
+  end
+
+  def update
+    position = Position.find_by!(id: params[:id],
+      course_code: params[:course_code].upcase)
+    position.update_attributes!(position_params)
+  end
+
+  private
+  def position_params
+    params.permit(:duties, :qualifications, :hours, :estimated_count,
+      :estimated_total_hours)
+  end
+
+end

--- a/app/controllers/positions_controller.rb
+++ b/app/controllers/positions_controller.rb
@@ -2,8 +2,7 @@ class PositionsController < ApplicationController
   protect_from_forgery with: :null_session
 
   def index
-    condition = {course_code: params[:course_code].upcase}
-    @course_positions = Position.where(condition)
+    @course_positions = Course.find(params[:course_code].upcase).positions
     render json: @course_positions.to_json()
   end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,6 +1,6 @@
 class Course < ApplicationRecord
   belongs_to :campus, foreign_key: 'campus_code'
   belongs_to :instructor, optional: true
-  has_many :positions
+  has_many :positions, foreign_key: 'course_code'
   validates :code, uniqueness: true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,8 @@ Rails.application.routes.draw do
   resources :applicants do
     resources :applications
   end
-
   resources :applications, only: [:index, :show]
-  get "/courses", to: "courses#list"
+  resources :courses, param: :code do
+    resources :positions
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,4 +8,5 @@ Rails.application.routes.draw do
   end
 
   resources :applications, only: [:index, :show]
+  get "/courses", to: "courses#list"
 end

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe CoursesController, type: :controller do
+  context "GET /courses" do
+    it "lists all courses" do
+      get :index
+      expect(response.status).to eq(200)
+      expect(response.body).not_to be_empty
+    end
+  end
+
+  describe "PATCH /courses/{code}" do
+    let(:course) do
+      Course.create!(
+        code: "CSC104H1S",
+        campus_code: 1,
+        instructor_id: nil,
+        course_name: "Computational Thinking",
+        estimated_enrolment: nil
+      )
+    end
+    context "when {code} is valid" do
+      before(:each) do
+        @params = {
+          code: course.code,
+          estimated_enrolment: 300}
+        put :update, params: @params
+      end
+
+      it "updates courses" do
+        course.reload
+        expect(course[:estimated_enrolment]).to eq(@params[:estimated_enrolment])
+      end
+    end
+
+    context "when {code} is a non-existent courses code" do
+      it "it throws status 404" do
+        patch :update, params: {code: "csc103h1s"}
+        expect(response.status).to eq(404)
+      end
+    end
+
+    context "when {code} is an integer" do
+      it "it throws status 404" do
+        patch :update, params: {code: 2}
+        expect(response.status).to eq(404)
+      end
+    end
+
+  end
+
+
+end

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -30,19 +30,13 @@ RSpec.describe CoursesController, type: :controller do
       it "updates courses" do
         course.reload
         expect(course[:estimated_enrolment]).to eq(@params[:estimated_enrolment])
+        expect(response.status).to eq(204)
       end
     end
 
     context "when {code} is a non-existent courses code" do
       it "it throws status 404" do
         patch :update, params: {code: "csc103h1s"}
-        expect(response.status).to eq(404)
-      end
-    end
-
-    context "when {code} is an integer" do
-      it "it throws status 404" do
-        patch :update, params: {code: 2}
         expect(response.status).to eq(404)
       end
     end

--- a/spec/controllers/positions_controller_spec.rb
+++ b/spec/controllers/positions_controller_spec.rb
@@ -1,0 +1,91 @@
+require 'rails_helper'
+
+RSpec.describe PositionsController, type: :controller do
+  let(:course) do
+    Course.create!(
+      code: "CSC104H1S",
+      campus_code: 1,
+      instructor_id: nil,
+      course_name: "Computational Thinking",
+      estimated_enrolment: nil
+    )
+  end
+
+  let(:position) do
+    course.positions.create!(
+      id: 2,
+      course_code: "CSC104H1S",
+      title: "CSC104H1S",
+      duties: "TA duties may include marking, leading skills development tutorials, Q&A/Exam/Assignment/Test Review sessions, and laboratories where noted.",
+      qualifications: "Must be enrolled in, or have completed, an undergraduate program in computer science or education (or equivalent). Demonstrated excellent English communication skills. Patience teaching technical concepts to students with a wide variety of non-technical backgrounds. Must have completed or be in the process of completing a course involving functional programming. Must be able to write code in the Intermediate Student Language of Racket, and trace it in the same manner as the Intermediate Student Language Stepper of the DrRacket development environment.",
+      hours: 54,
+      estimated_count: 17,
+      estimated_total_hours: nil
+    )
+  end
+
+  describe "GET /courses/{course_code}/positions" do
+    context "when {course_code} exists" do
+      it "lists all positions of {course_code}" do
+        get :index, params: {course_code: position.course_code}
+        expect(response.status).to eq(200)
+        expect(response.body).not_to be_empty
+      end
+    end
+
+    context "when {course_code} is a non-existent courses code" do
+      it "throws status 404" do
+        get :index, params: {course_code: "csc103h1s"}
+        expect(response.status).to eq(404)
+      end
+    end
+
+    context "when {course_code} is an integer" do
+      it "throws status 404" do
+        get :index, params: {course_code: 2}
+        expect(response.status).to eq(404)
+      end
+    end
+  end
+
+  describe "PATCH /courses/{course_code}/positions/{id}" do
+    context "when {id} is valid for {course_code}" do
+      before(:each) do
+        @params = {
+          id: position.id,
+          course_code: position.course_code,
+          duties: "simplified duties",
+          qualifications: "qualifications",
+          hours: 20,
+          estimated_count: 15,
+          estimated_total_hours: 300}
+        put :update, params: @params
+      end
+
+      it "updates position with {id}" do
+        position.reload
+        expect(position.as_json(:except => [:title, :created_at, :updated_at]))
+          .to eq(@params.as_json)
+      end
+    end
+
+    context "when {id} is not valid for {course_code}" do
+      before(:each) do
+        @params = {
+          id: 12,
+          course_code: position.course_code,
+          duties: "simplified duties",
+          qualifications: "qualifications",
+          hours: 20,
+          estimated_count: 15,
+          estimated_total_hours: 300}
+        put :update, params: @params
+      end
+
+      it "throws a status 404" do
+        expect(response.status).to eq(404)
+      end
+    end
+
+  end
+end

--- a/spec/controllers/positions_controller_spec.rb
+++ b/spec/controllers/positions_controller_spec.rb
@@ -39,13 +39,6 @@ RSpec.describe PositionsController, type: :controller do
         expect(response.status).to eq(404)
       end
     end
-
-    context "when {course_code} is an integer" do
-      it "throws status 404" do
-        get :index, params: {course_code: 2}
-        expect(response.status).to eq(404)
-      end
-    end
   end
 
   describe "PATCH /courses/{course_code}/positions/{id}" do
@@ -66,6 +59,7 @@ RSpec.describe PositionsController, type: :controller do
         position.reload
         expect(position.as_json(:except => [:title, :created_at, :updated_at]))
           .to eq(@params.as_json)
+          expect(response.status).to eq(204)
       end
     end
 


### PR DESCRIPTION
- continuation of PR #31
- added `GET /courses` & `GET /courses/{course_code}/positions/`
- add `PATCH /courses/{course_code}` & `PATCH /courses/{course_code}/position/{id}`
- page should display an array of JSON with the following attributes:
  * code
  * campus_code
  * instructor_id
  * course_name
  * estimated_enrolment
  * created_at
  * updated_at
  * positions: this an array with object containing the following attributes
    * id
    * course_code
    * title
    * duties
    * qualifications
    * hours
    * estimated_count
    * estimated_total_hours
    * created_at
    * updated_at
- for a listing of all courses go to `/courses`
- for a listing of all position for a specific course (i.e. "CSC108H1S") go to `/courses/csc108h1s/positions/`

- to test `PATCH` API use Postman:
  - the `estimated_enrolment` is the only attribute editable fields in Course model
  - the following are the editable attributes in Position model
    * duties
    * qualifications
    * hours
    * estimated_count
    * estimated_total_hours

- invalid `{course_code}` and `{id}` should both throw a `status: 404`

