### PR TITLE
Route index.html/anything to app#main

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,6 @@ Rails.application.routes.draw do
   end
 
   resources :applications, only: [:index, :show]
-  
-  get "/index.html", to: "app#main"
 
+  get "/index.html/(*z)", to: "app#main"
 end


### PR DESCRIPTION
This PR routes anything starting with `index.html` to `app#main`. In conjunction with the React app we have, you should be able to:
  1. Go to http://localhost:3000/index.html
  2. Click on any tab in the navbar and see the navigation reflected on the page
  3. Reload the page — and still be on the same tab in the React app!