### PR TITLE
Add List of Instructors for each Position

### DIFF
--- a/app/controllers/instructors_controller.rb
+++ b/app/controllers/instructors_controller.rb
@@ -1,0 +1,14 @@
+class InstructorsController < ApplicationController
+  protect_from_forgery with: :null_session
+
+  def index
+    instructors = Instructor.all
+    render json: instructors.to_json
+  end
+
+  def show
+    instructor = Instructor.find(params[:id])
+    render json: instructor.to_json
+  end
+
+end

--- a/app/controllers/positions_controller.rb
+++ b/app/controllers/positions_controller.rb
@@ -2,13 +2,13 @@ class PositionsController < ApplicationController
   protect_from_forgery with: :null_session
 
   def index
-    @positions = Position.all
-    render json: @positions.to_json
+    @positions = Position.all.includes(:instructors)
+    render json: @positions.to_json(include: [:instructors])
   end
 
   def show
-    position = Position.find(params[:id])
-    render json: position.to_json
+    position = Position.includes(:instructors).find(params[:id])
+    render json: position.to_json(include: [:instructors])
   end
 
   def update

--- a/app/controllers/positions_controller.rb
+++ b/app/controllers/positions_controller.rb
@@ -14,6 +14,12 @@ class PositionsController < ApplicationController
   def update
     position = Position.find(params[:id])
     position.update_attributes!(position_params)
+    if params[:instructors]
+      puts 'not null'
+      position.instructor_ids = JSON.parse params[:instructors]
+    else
+      puts 'null'
+    end
   end
 
   private

--- a/app/controllers/positions_controller.rb
+++ b/app/controllers/positions_controller.rb
@@ -15,10 +15,7 @@ class PositionsController < ApplicationController
     position = Position.find(params[:id])
     position.update_attributes!(position_params)
     if params[:instructors]
-      puts 'not null'
-      position.instructor_ids = JSON.parse params[:instructors]
-    else
-      puts 'null'
+      position.instructor_ids = params[:instructors]
     end
   end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,6 +1,0 @@
-class Course < ApplicationRecord
-  belongs_to :campus, foreign_key: 'campus_code'
-  belongs_to :instructor, optional: true
-  has_many :positions, foreign_key: 'course_code'
-  validates :code, uniqueness: true
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,4 +8,5 @@ Rails.application.routes.draw do
   end
   resources :applications, only: [:index, :show]
   resources :positions
+  resources :instructors
 end

--- a/db/seeds/mock_chass.json
+++ b/db/seeds/mock_chass.json
@@ -54,7 +54,7 @@
     "status": "1",
     "end_nominations": null,
     "last_updated": "2017-05-31 10:55:56",
-    "instructors": ["Tom Fairgrieve', 'Paul Gries"]
+    "instructors": ["Tom Fairgrieve", "Paul Gries"]
   },
   {
     "course_id": "CSC108H1S-Student-Facing_TA",
@@ -73,7 +73,7 @@
     "status": "1",
     "end_nominations": null,
     "last_updated": "2017-05-31 10:55:56",
-    "instructors": ["Tom Fairgrieve', 'Paul Gries"]
+    "instructors": ["Tom Fairgrieve", "Paul Gries"]
   },
   {
     "course_id": "CSC108H1S-Marking_TA",
@@ -92,7 +92,7 @@
     "status": "1",
     "end_nominations": null,
     "last_updated": "2017-05-31 10:55:56",
-    "instructors": ["Tom Fairgrieve', 'Paul Gries"]
+    "instructors": ["Tom Fairgrieve", "Paul Gries"]
   },
   {
     "course_id": "CSC108H5S",
@@ -149,7 +149,7 @@
     "status": "1",
     "end_nominations": null,
     "last_updated": "2017-05-31 10:55:56",
-    "instructors": ["Bogdan Simion', 'Danny Heap', 'Jacqueline Smith"]
+    "instructors": ["Bogdan Simion", "Danny Heap", "Jacqueline Smith"]
   },
   {
     "course_id": "CSC148H5S",
@@ -187,7 +187,7 @@
     "status": "1",
     "end_nominations": null,
     "last_updated": "2017-05-31 10:55:56",
-    "instructors": ["David Liu', 'Toniann Pitassi"]
+    "instructors": ["David Liu", "Toniann Pitassi"]
   },
   {
     "course_id": "CSC207H1S",
@@ -301,7 +301,7 @@
     "status": "1",
     "end_nominations": null,
     "last_updated": "2017-05-31 10:55:56",
-    "instructors": ["Sajad Shirali-Shahreza', 'Steve Engels"]
+    "instructors": ["Sajad Shirali-Shahreza", "Steve Engels"]
   },
   {
     "course_id": "CSC258H5S",
@@ -339,7 +339,7 @@
     "status": "1",
     "end_nominations": null,
     "last_updated": "2017-05-31 10:55:56",
-    "instructors": ["Francois Pitt', 'Sam Toueg', 'Sasa Milic"]
+    "instructors": ["Francois Pitt", "Sam Toueg", "Sasa Milic"]
   },
   {
     "course_id": "CSC300H1S",
@@ -795,7 +795,7 @@
     "status": "1",
     "end_nominations": null,
     "last_updated": "2017-05-31 10:55:56",
-    "instructors": ["David Levin', 'Edy Garfinkiel"]
+    "instructors": ["David Levin", "Edy Garfinkiel"]
   },
   {
     "course_id": "CSC420H5S",

--- a/docs/api/instructors.yml
+++ b/docs/api/instructors.yml
@@ -1,0 +1,67 @@
+swagger: "2.0"
+info:
+  description: "This is API for the course endpoint of the DCS-TA app."
+  version: "1.0.0"
+  title: "DCS-TA app"
+basePath: "/v2"
+tags:
+- name: "dcs-ta"
+  description: "DCS-TA application"
+paths:
+  /instructors:
+    get:
+      tags:
+      - "instructors"
+      summary: "Get all Instructors"
+      produces:
+      - "application/json"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Instructor"
+  /instructors/{id}:
+    get:
+      tags:
+       - "instructors"
+      summary: "Get Instructor {id} Information"
+      parameters:
+      - in: path
+        name: id
+        type: integer
+        required: true
+        description: "id for an Instructor in the Instructor Table"
+      produces:
+      - "application/json"
+      responses:
+        404:
+          description: "No Instructor with {id}"
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Instructor"
+definitions:
+  Instructor:
+    type: object
+    properties:
+      id:
+        type: integer
+        example: 1
+      name:
+        type: string
+        example: "Instructor Name"
+      email:
+        type: string
+        example: "email@example.com"
+      created_at:
+        type: string
+        format: date-time
+        example: "2017-06-22T15:43:02.952Z"
+      updated_at:
+        type: string
+        format: date-time
+        example: "2017-06-22T15:43:02.952Z"

--- a/docs/api/positions.yml
+++ b/docs/api/positions.yml
@@ -137,7 +137,12 @@ definitions:
         description: "estimated amount of TA's needed for this position"
       estimated_total_hours:
         type: "integer"
-        example: 100
+        example: 10
+      instructors:
+        type: array
+        example: "[2, 4]"
+        items:
+          type: integer
   Instructor:
     type: object
     properties:

--- a/docs/api/positions.yml
+++ b/docs/api/positions.yml
@@ -111,6 +111,10 @@ definitions:
         type: "string"
         format: "date-time"
         example: "2017-06-05T14:26:44.808Z"
+      instructors:
+        type: array
+        items:
+          $ref: "#/definitions/Instructor"
   Position_Update:
     type: "object"
     properties:
@@ -134,3 +138,23 @@ definitions:
       estimated_total_hours:
         type: "integer"
         example: 100
+  Instructor:
+    type: object
+    properties:
+      id:
+        type: integer
+        example: 1
+      name:
+        type: string
+        example: "Instructor Name"
+      email:
+        type: string
+        example: "email@example.com"
+      created_at:
+        type: string
+        format: date-time
+        example: "2017-06-22T15:43:02.952Z"
+      updated_at:
+        type: string
+        format: date-time
+        example: "2017-06-22T15:43:02.952Z"

--- a/spec/controllers/instructors_controller_spec.rb
+++ b/spec/controllers/instructors_controller_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe InstructorsController, type: :controller do
+
+  let(:instructor) do
+    Instructor.create!(
+      name: "instructor name",
+      email: "email@example.com"
+    )
+  end
+
+  describe "GET /instructors/" do
+    context "when expected" do
+      it "lists all instructors" do
+        get :index
+        expect(response.status).to eq(200)
+        expect(response.body).not_to be_empty
+      end
+    end
+
+    context "when /instructors/{id} exists" do
+      it "lists instructors with {id}" do
+        get :show, params: {id: instructor[:id]}
+        expect(response.status).to eq(200)
+        expect(response.body).not_to be_empty
+      end
+    end
+
+    context "when {id} is a non-existent id" do
+      it "throws status 404" do
+        get :show, params: {id: "poop"}
+        expect(response.status).to eq(404)
+      end
+    end
+  end
+
+end

--- a/spec/controllers/positions_controller_spec.rb
+++ b/spec/controllers/positions_controller_spec.rb
@@ -59,14 +59,18 @@ RSpec.describe PositionsController, type: :controller do
           qualifications: "qualifications",
           hours: 20,
           estimated_count: 15,
-          estimated_total_hours: 300}
+          estimated_total_hours: 300,
+          instructors: "[2, 4]"
+        }
+        expect(position.instructor_ids).to eq([])
         put :update, params: @params
       end
 
       it "updates position with {id}" do
         position.reload
-        expect(position.as_json(:except => [:title, :created_at, :updated_at]))
-          .to eq(@params.as_json)
+        expect(position.as_json(:except => [:title, :created_at, :updated_at, :instructors]))
+          .to eq(@params.as_json(:except => [:instructors]))
+        expect(position.instructor_ids).to eq([2,4])
           expect(response.status).to eq(204)
       end
     end

--- a/spec/controllers/positions_controller_spec.rb
+++ b/spec/controllers/positions_controller_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe PositionsController, type: :controller do
           hours: 20,
           estimated_count: 15,
           estimated_total_hours: 300,
-          instructors: "[2, 4]"
+          instructors: [2, 4]
         }
         expect(position.instructor_ids).to eq([])
         put :update, params: @params


### PR DESCRIPTION
- fix syntax error in `mock_chass.json`
- add `instructors` attribute to each `Instructor` object in JSON
- updated API documentation to include `instructors` attribute
- added `/instructors` route
  - `/instructors` gets all instructors in the system
  - `/instructors/:id` get an instructor by its `id`
    - it returns `status: 404` if the `Instructor` with `id` doesn't exist
- added `instructors` as an editable attribute in `PATCH /positions/:id`
- remove `app/models/course.rb`
- added API documentation for `instructors` route