### PR TITLE
add csv file to /export route

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -60,15 +60,15 @@ class AssignmentsController < ApplicationController
   '''
     update #PATCH
     /applicants/:applicant_id/assignments/:id
-    hours, export_date
+    hours
 
-    updates the hours and export_date column for an applicant given assignment ID and applicant ID
+    updates the hours column for an applicant given assignment ID and applicant ID
   '''
   def update
     @applicant = Applicant.find(params[:applicant_id])
     assignment = @applicant.assignments.find(params[:id])
 
-    if assignment.update_attributes(updateable_params)
+    if assignment.update_attributes(hours: params[:hours])
       render json: assignment.to_json
     else
       render json: assignment.errors.to_hash(true), status: :unprocessable_entity
@@ -97,7 +97,4 @@ class AssignmentsController < ApplicationController
       params.permit(:position_id, :hours)
     end
 
-    def updateable_params
-      params.permit(:hours, :export_date)
-    end
 end

--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -10,7 +10,6 @@ class ExportController < ApplicationController
   def cdf
     generator = CSVGenerator.new
     response = generator.generate_cdf_info
-    puts response
     render_helper(response)
   end
 

--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -28,12 +28,12 @@ class ExportController < ApplicationController
   private
   def render_helper(response)
     if response[:generated]
-      send_data response[:data], :filename => response[:file]
+      send_data response[:data], :filename => response[:file],
+      content_type: response[:type]
     else
       render status: 404, json: {
         message: response[:msg]
-      }.to_json,
-      content_type: response[:type]
+      }.to_json
     end
   end
 

--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -4,8 +4,32 @@ class ExportController < ApplicationController
   def chass
     exporter = ChassExporter.new
     response = exporter.export(params[:round_id])
+    render_helper(response)
+  end
+
+  def cdf
+    generator = CSVGenerator.new
+    response = generator.generate_cdf_info
+    puts response
+    render_helper(response)
+  end
+
+  def offers
+    generator = CSVGenerator.new
+    response = generator.generate_offers
+    render_helper(response)
+  end
+
+  def transcript_access
+    generator = CSVGenerator.new
+    response = generator.generate_transcript_access
+    render_helper(response)
+  end
+
+  private
+  def render_helper(response)
     if response[:generated]
-      send_file("#{Rails.root}/db/seeds/export_data.json")
+      send_file("#{Rails.root}/db/seeds/#{response[:file]}")
     else
       render status: 404, json: {
         message: response[:msg]

--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -29,7 +29,7 @@ class ExportController < ApplicationController
   private
   def render_helper(response)
     if response[:generated]
-      send_file("#{Rails.root}/db/seeds/#{response[:file]}")
+      send_data response[:data], :filename => response[:file]
     else
       render status: 404, json: {
         message: response[:msg]

--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -32,7 +32,8 @@ class ExportController < ApplicationController
     else
       render status: 404, json: {
         message: response[:msg]
-      }.to_json
+      }.to_json,
+      content_type: response[:type]
     end
   end
 

--- a/app/services/chass_exporter.rb
+++ b/app/services/chass_exporter.rb
@@ -12,7 +12,8 @@ class ChassExporter
         else
           data = create_data(round_id)
           write_export_file(data)
-          return {generated: true, msg: "Success: Assignments have been exported"}
+          return {generated: true, msg: "Success: Assignments have been exported",
+            file: "export_data.json"}
         end
       else
         return {generated: false, msg: "Error: Invalid round_id"}

--- a/app/services/chass_exporter.rb
+++ b/app/services/chass_exporter.rb
@@ -11,8 +11,7 @@ class ChassExporter
           return {generated: false, msg: "Warning: You have not made any assignments. Operation aborted."}
         else
           data = create_data(round_id)
-          write_export_file(data, round_id)
-          return {generated: true, msg: "Success: Assignments have been exported",
+          return {generated: true, data: data,
             file: "offers_#{round_id}.json"}
         end
       else
@@ -21,13 +20,6 @@ class ChassExporter
     end
 
     private
-    def write_export_file(data, round_id)
-      json = JSON.pretty_generate(data)
-      File.open("#{Rails.root}/db/seeds/offers_#{round_id}.json", "w") do |file|
-        file.puts "assignments = #{json}"
-      end
-    end
-
     def is_valid_round_id(round_id)
       @positions = Position.all
       valid = false

--- a/app/services/chass_exporter.rb
+++ b/app/services/chass_exporter.rb
@@ -11,8 +11,8 @@ class ChassExporter
           return {generated: false, msg: "Warning: You have not made any assignments. Operation aborted."}
         else
           data = create_data(round_id)
-          return {generated: true, data: data,
-            file: "offers_#{round_id}.json"}
+          return {generated: true, data: data, file: "offers_#{round_id}.json",
+            type: "application/json"}
         end
       else
         return {generated: false, msg: "Error: Invalid round_id"}

--- a/app/services/chass_exporter.rb
+++ b/app/services/chass_exporter.rb
@@ -11,9 +11,9 @@ class ChassExporter
           return {generated: false, msg: "Warning: You have not made any assignments. Operation aborted."}
         else
           data = create_data(round_id)
-          write_export_file(data)
+          write_export_file(data, round_id)
           return {generated: true, msg: "Success: Assignments have been exported",
-            file: "export_data.json"}
+            file: "offers_#{round_id}.json"}
         end
       else
         return {generated: false, msg: "Error: Invalid round_id"}
@@ -21,9 +21,9 @@ class ChassExporter
     end
 
     private
-    def write_export_file(data)
+    def write_export_file(data, round_id)
       json = JSON.pretty_generate(data)
-      File.open("#{Rails.root}/db/seeds/export_data.json", "w") do |file|
+      File.open("#{Rails.root}/db/seeds/offers_#{round_id}.json", "w") do |file|
         file.puts "assignments = #{json}"
       end
     end

--- a/app/services/csv_generator.rb
+++ b/app/services/csv_generator.rb
@@ -22,8 +22,7 @@ class CSVGenerator
         "utorid",
       ]
       data = get_cdf_info(attributes)
-      write_export_file("cdf_info", data)
-      return {generated: true, msg: "Success: CDF info CSV file created",
+      return {generated: true, data: data,
         file: "cdf_info.csv"}
     end
   end
@@ -46,9 +45,8 @@ class CSVGenerator
         "round_id",
       ]
       data = get_offers(attributes)
-      write_export_file("offers", data)
       return {generated: true,
-        msg: "Success: Offer CSV file created", file: "offers.csv"}
+        data: data, file: "offers.csv"}
     end
   end
 
@@ -65,19 +63,12 @@ class CSVGenerator
         "email_address"
       ]
       data = get_transcript_access(attributes)
-      write_export_file("transcript_access", data)
       return {generated: true,
-        msg: "Success: Transcript Access CSV file created", file: "transcript_access.csv"}
+        data: data, file: "transcript_access.csv"}
     end
   end
 
   private
-  def write_export_file(file, data)
-    File.open("#{Rails.root}/db/seeds/#{file}.csv", "w") do |file|
-      file.puts "#{data}"
-    end
-  end
-
   def get_cdf_info(attributes)
     data = CSV.generate do |csv|
       csv << attributes

--- a/app/services/csv_generator.rb
+++ b/app/services/csv_generator.rb
@@ -9,7 +9,8 @@ class CSVGenerator
 
   def generate_cdf_info
     if @assignments.size == 0
-      puts "Warning: You have not made any assignments yet. Operation aborted"
+      return {generated: false,
+        msg: "Warning: You have not made any assignments yet. Operation aborted"}
     else
       attributes = [
         "course_code",
@@ -22,13 +23,15 @@ class CSVGenerator
       ]
       data = get_cdf_info(attributes)
       write_export_file("cdf_info", data)
-      puts "Success: CDF info CSV file created"
+      return {generated: true, msg: "Success: CDF info CSV file created",
+        file: "cdf_info.csv"}
     end
   end
 
   def generate_offers
     if @assignments.size == 0
-      puts "Warning: You have not made any assignments yet. Operation aborted"
+      return {generated: false,
+        msg: "Warning: You have not made any assignments yet. Operation aborted"}
     else
       attributes = [
         "course_code",
@@ -44,13 +47,15 @@ class CSVGenerator
       ]
       data = get_offers(attributes)
       write_export_file("offers", data)
-      puts "Success: Offer CSV file created"
+      return {generated: true,
+        msg: "Success: Offer CSV file created", file: "offers.csv"}
     end
   end
 
   def generate_transcript_access
     if @applicants.size == 0
-      puts "Warning: There are currenly no applicant in the system. Operation aborted"
+      return {generated: false,
+        msg: "Warning: There are currenly no applicant in the system. Operation aborted"}
     else
       attributes = [
         "student_number",
@@ -61,7 +66,8 @@ class CSVGenerator
       ]
       data = get_transcript_access(attributes)
       write_export_file("transcript_access", data)
-      puts "Suceess: Transcript Access CSV file created"
+      return {generated: true,
+        msg: "Success: Transcript Access CSV file created", file: "transcript_access.csv"}
     end
   end
 

--- a/app/services/csv_generator.rb
+++ b/app/services/csv_generator.rb
@@ -10,7 +10,7 @@ class CSVGenerator
   def generate_cdf_info
     if @assignments.size == 0
       return {generated: false,
-        msg: "Warning: You have not made any assignments yet. Operation aborted"}
+        msg: "Warning: You have not made any assignments. Operation aborted."}
     else
       attributes = [
         "course_code",
@@ -22,15 +22,14 @@ class CSVGenerator
         "utorid",
       ]
       data = get_cdf_info(attributes)
-      return {generated: true, data: data,
-        file: "cdf_info.csv"}
+      return {generated: true, data: data, file: "cdf_info.csv", type: "text/csv"}
     end
   end
 
   def generate_offers
     if @assignments.size == 0
       return {generated: false,
-        msg: "Warning: You have not made any assignments yet. Operation aborted"}
+        msg: "Warning: You have not made any assignments. Operation aborted."}
     else
       attributes = [
         "course_code",
@@ -45,8 +44,7 @@ class CSVGenerator
         "round_id",
       ]
       data = get_offers(attributes)
-      return {generated: true,
-        data: data, file: "offers.csv"}
+      return {generated: true, data: data, file: "offers.csv", type: "text/csv"}
     end
   end
 
@@ -63,8 +61,7 @@ class CSVGenerator
         "email_address"
       ]
       data = get_transcript_access(attributes)
-      return {generated: true,
-        data: data, file: "transcript_access.csv"}
+      return {generated: true, data: data, file: "transcript_access.csv", type: "text/csv"}
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,4 +13,7 @@ Rails.application.routes.draw do
   get "/index.html/(*z)", to: "app#main"
 
   get "/export/chass/:round_id", to: "export#chass"
+  get "/export/cdf-info", to: "export#cdf"
+  get "/export/transcript-access", to: "export#transcript_access"
+  get "/export/offers", to: "export#offers"
 end

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -296,21 +296,6 @@ RSpec.describe AssignmentsController, type: :controller do
       expect(response.status).to eq(422)
     end
 
-    context "when updating export_date" do
-      it "return status 200 if valid and updated" do
-        time = Time.now.strftime("%Y-%d-%mT%H:%M:%S.000Z")
-        patch :update, params: { applicant_id: @applicant.id, id: @assignment.id, export_date: time }
-        expect(response.status).to eq(200)
-        expect(parsed_body["export_date"]).to eq(time)
-      end
-
-      it "return status 200 and ignores the request if invalid" do
-        patch :update, params: { applicant_id: @applicant.id, id: @assignment.id, export_date: "poops" }
-        expect(response.status).to eq(200)
-        expect(parsed_body["export_date"]).to eq(nil)
-      end
-    end
-
   end
 
 

--- a/spec/controllers/export_controller_spec.rb
+++ b/spec/controllers/export_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe ExportController, type: :controller do
   let(:position) do
     Position.create!(
-    position: "CSC411",
+    position: "CSC411 - test 3",
     round_id: "110",
     open: true,
     campus_code: 1,
@@ -44,7 +44,7 @@ RSpec.describe ExportController, type: :controller do
         address: "100 Jameson Ave Toronto, ON M65-48H"
       )
       @application = @applicant.applications.create!(
-        app_id: "1",
+        app_id: "14",
         round_id: "110",
         ta_training: "N",
         access_acad_history: "Y",
@@ -61,6 +61,7 @@ RSpec.describe ExportController, type: :controller do
       it "returns status 200 and downloads transcript_access.csv" do
         get :transcript_access
         expect(response.status).to eq(200)
+        expect(response.content_type).to eq("text/csv")
         expect(response.header["Content-Disposition"]).to eq(
           "attachment; filename=\"transcript_access.csv\"")
       end
@@ -70,7 +71,7 @@ RSpec.describe ExportController, type: :controller do
       context "when calling #chass" do
         context "when round_id is valid" do
           it "returns status 404 and an error message" do
-            get :chass, params: {round_id: 110}
+            get :chass, params: {round_id: position[:round_id]}
             message = {message:
               "Warning: You have not made any assignments. Operation aborted."}
             expect(response.status).to eq(404)
@@ -125,7 +126,7 @@ RSpec.describe ExportController, type: :controller do
 
         context "when round_id is valid" do
           it "returns status 200 and downloads offers_(round_id).json" do
-            get :chass, params: {round_id: 110}
+            get :chass, params: {round_id: position[:round_id]}
             expect(response.status).to eq(200)
             expect(response.content_type).to eq("application/json")
             expect(response.header["Content-Disposition"]).to eq(
@@ -140,6 +141,7 @@ RSpec.describe ExportController, type: :controller do
         it "returns status 200 and downloads cdf_info.csv" do
           get :cdf
           expect(response.status).to eq(200)
+          expect(response.content_type).to eq("text/csv")
           expect(response.header["Content-Disposition"]).to eq(
             "attachment; filename=\"cdf_info.csv\"")
         end
@@ -150,6 +152,7 @@ RSpec.describe ExportController, type: :controller do
         it "returns status 200 and downloads offers.csv" do
           get :offers
           expect(response.status).to eq(200)
+          expect(response.content_type).to eq("text/csv")
           expect(response.header["Content-Disposition"]).to eq(
             "attachment; filename=\"offers.csv\"")
         end

--- a/spec/controllers/export_controller_spec.rb
+++ b/spec/controllers/export_controller_spec.rb
@@ -1,0 +1,160 @@
+require 'rails_helper'
+
+RSpec.describe ExportController, type: :controller do
+  let(:position) do
+    Position.create!(
+    position: "CSC411",
+    round_id: "110",
+    open: true,
+    campus_code: 1,
+    course_name: "Introduction to Software Testing",
+    estimated_enrolment: 50,
+    duties: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eget dignissim sem. Curabitur at semper eros. Aenean nec sem lobortis, scelerisque mi at, aliquam diam. Mauris malesuada elit nibh, sed hendrerit nulla mattis sed. Mauris laoreet imperdiet dictum. Pellentesque risus nulla, varius ut massa ut, venenatis fringilla sapien. Cras eget euismod augue, eget dignissim erat. Cras nec nibh ullamcorper ante rutrum dapibus sed nec tellus. In hac habitasse platea dictumst. Suspendisse semper tellus ac sem tincidunt auctor.",
+    qualifications: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eget dignissim sem. Curabitur at semper eros. Aenean nec sem lobortis, scelerisque mi at, aliquam diam. Mauris malesuada elit nibh, sed hendrerit nulla mattis sed. Mauris laoreet imperdiet dictum. Pellentesque risus nulla, varius ut massa ut, venenatis fringilla sapien. Cras eget euismod augue, eget dignissim erat. Cras nec nibh ullamcorper ante rutrum dapibus sed nec tellus. In hac habitasse platea dictumst. Suspendisse semper tellus ac sem tincidunt auctor.",
+    hours: 22,
+    estimated_count: 15,
+    estimated_total_hours: 330
+    )
+  end
+
+  context "when there are no applicants in the system" do
+    context "when calling #transcript_access" do
+      it "returns status 404 and an error message" do
+        get :transcript_access
+        message = {message:
+          "Warning: There are currenly no applicant in the system. Operation aborted"}
+        expect(response.status).to eq(404)
+        expect(response.body).to eq(message.to_json)
+      end
+    end
+  end
+
+  context "when there are applicants in the system" do
+    before(:each) do
+      @applicant = Applicant.create!(
+        utorid: "cookie222",
+        student_number: 1234567890,
+        first_name: "Landy",
+        last_name: "Simpson",
+        dept: "Computer Science",
+        program_id: "4UG",
+        yip: 4,
+        email: "simps@mail.com",
+        phone: "4165558888",
+        address: "100 Jameson Ave Toronto, ON M65-48H"
+      )
+      @application = @applicant.applications.create!(
+        app_id: "1",
+        round_id: "110",
+        ta_training: "N",
+        access_acad_history: "Y",
+        ta_experience: "CSC373H1S (2), CSC318H1S (5), CSC423H5S (4), CSC324H1S (9), CSC404H1S (8)",
+        academic_qualifications: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eget dignissim sem. Curabitur at semper eros. Aenean nec sem lobortis, scelerisque mi at, aliquam diam. Mauris malesuada elit nibh, sed hendrerit nulla mattis sed. Mauris laoreet imperdiet dictum. Pellentesque risus nulla, varius ut massa ut, venenatis fringilla sapien. Cras eget euismod augue, eget dignissim erat. Cras nec nibh ullamcorper ante rutrum dapibus sed nec tellus. In hac habitasse platea dictumst. Suspendisse semper tellus ac sem tincidunt auctor.",
+        technical_skills: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eget dignissim sem. Curabitur at semper eros. Aenean nec sem lobortis, scelerisque mi at, aliquam diam. Mauris malesuada elit nibh, sed hendrerit nulla mattis sed. Mauris laoreet imperdiet dictum. Pellentesque risus nulla, varius ut massa ut, venenatis fringilla sapien. Cras eget euismod augue, eget dignissim erat. Cras nec nibh ullamcorper ante rutrum dapibus sed nec tellus. In hac habitasse platea dictumst. Suspendisse semper tellus ac sem tincidunt auctor.",
+        availability: "MW 9-8, RF 12-7",
+        other_info: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eget dignissim sem. Curabitur at semper eros. Aenean nec sem lobortis, scelerisque mi at, aliquam diam. Mauris malesuada elit nibh, sed hendrerit nulla mattis sed. Mauris laoreet imperdiet dictum. Pellentesque risus nulla, varius ut massa ut, venenatis fringilla sapien. Cras eget euismod augue, eget dignissim erat. Cras nec nibh ullamcorper ante rutrum dapibus sed nec tellus. In hac habitasse platea dictumst. Suspendisse semper tellus ac sem tincidunt auctor.",
+        special_needs: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eget dignissim sem. Curabitur at semper eros. Aenean nec sem lobortis, scelerisque mi at, aliquam diam. Mauris malesuada elit nibh, sed hendrerit nulla mattis sed. Mauris laoreet imperdiet dictum. Pellentesque risus nulla, varius ut massa ut, venenatis fringilla sapien. Cras eget euismod augue, eget dignissim erat. Cras nec nibh ullamcorper ante rutrum dapibus sed nec tellus. In hac habitasse platea dictumst. Suspendisse semper tellus ac sem tincidunt auctor."
+        )
+    end
+
+    context "when calling #transcript_access" do
+      it "returns status 200 and downloads transcript_access.csv" do
+        get :transcript_access
+        expect(response.status).to eq(200)
+        expect(response.header["Content-Disposition"]).to eq(
+          "attachment; filename=\"transcript_access.csv\"")
+      end
+    end
+
+    context "when there are no assignments in the system" do
+      context "when calling #chass" do
+        context "when round_id is valid" do
+          it "returns status 404 and an error message" do
+            get :chass, params: {round_id: 110}
+            message = {message:
+              "Warning: You have not made any assignments. Operation aborted."}
+            expect(response.status).to eq(404)
+            expect(response.body).to eq(message.to_json)
+          end
+
+        end
+
+      end
+
+      context "when calling #cdf" do
+        it "returns status 404 and an error message" do
+          get :cdf
+          expect(response.status).to eq(404)
+          message = {message:
+            "Warning: You have not made any assignments. Operation aborted."}
+          expect(response.status).to eq(404)
+          expect(response.body).to eq(message.to_json)
+        end
+
+      end
+
+      context "when calling #offers" do
+        it "returns status 404 and an error message" do
+          get :offers
+          expect(response.status).to eq(404)
+          message = {message:
+            "Warning: You have not made any assignments. Operation aborted."}
+          expect(response.status).to eq(404)
+          expect(response.body).to eq(message.to_json)
+        end
+      end
+    end
+
+    context "when there are assignments in the system" do
+      before(:each) do
+        @applicant.assignments.create!(
+          position_id: position.id,
+          hours: 50
+        )
+      end
+      context "when calling #chass" do
+        context "when round_id is invalid" do
+          it "returns status 404 and an error message" do
+            get :chass, params: {round_id: 1}
+            message = {message: "Error: Invalid round_id"}
+            expect(response.status).to eq(404)
+            expect(response.body).to eq(message.to_json)
+          end
+
+        end
+
+        context "when round_id is valid" do
+          it "returns status 200 and downloads offers_(round_id).json" do
+            get :chass, params: {round_id: 110}
+            expect(response.status).to eq(200)
+            expect(response.content_type).to eq("application/json")
+            expect(response.header["Content-Disposition"]).to eq(
+              "attachment; filename=\"offers_110.json\"")
+          end
+
+        end
+
+      end
+
+      context "when calling #cdf" do
+        it "returns status 200 and downloads cdf_info.csv" do
+          get :cdf
+          expect(response.status).to eq(200)
+          expect(response.header["Content-Disposition"]).to eq(
+            "attachment; filename=\"cdf_info.csv\"")
+        end
+
+      end
+
+      context "when calling #offers" do
+        it "returns status 200 and downloads offers.csv" do
+          get :offers
+          expect(response.status).to eq(200)
+          expect(response.header["Content-Disposition"]).to eq(
+            "attachment; filename=\"offers.csv\"")
+        end
+      end
+    end
+  end
+
+end

--- a/spec/services/chass_exporter_spec.rb
+++ b/spec/services/chass_exporter_spec.rb
@@ -1,0 +1,92 @@
+require 'rails_helper'
+
+describe ChassExporter do
+  let (:exporter) { ChassExporter.new }
+  let(:position) do
+    Position.create!(
+    position: "CSC411",
+    round_id: "110",
+    open: true,
+    campus_code: 1,
+    course_name: "Introduction to Software Testing",
+    estimated_enrolment: 50,
+    duties: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eget dignissim sem. Curabitur at semper eros. Aenean nec sem lobortis, scelerisque mi at, aliquam diam. Mauris malesuada elit nibh, sed hendrerit nulla mattis sed. Mauris laoreet imperdiet dictum. Pellentesque risus nulla, varius ut massa ut, venenatis fringilla sapien. Cras eget euismod augue, eget dignissim erat. Cras nec nibh ullamcorper ante rutrum dapibus sed nec tellus. In hac habitasse platea dictumst. Suspendisse semper tellus ac sem tincidunt auctor.",
+    qualifications: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eget dignissim sem. Curabitur at semper eros. Aenean nec sem lobortis, scelerisque mi at, aliquam diam. Mauris malesuada elit nibh, sed hendrerit nulla mattis sed. Mauris laoreet imperdiet dictum. Pellentesque risus nulla, varius ut massa ut, venenatis fringilla sapien. Cras eget euismod augue, eget dignissim erat. Cras nec nibh ullamcorper ante rutrum dapibus sed nec tellus. In hac habitasse platea dictumst. Suspendisse semper tellus ac sem tincidunt auctor.",
+    hours: 22,
+    estimated_count: 15,
+    estimated_total_hours: 330
+    )
+  end
+
+  let(:applicant) do
+    Applicant.create!(
+    utorid: "cookie222",
+    student_number: 1234567890,
+    first_name: "Landy",
+    last_name: "Simpson",
+    dept: "Computer Science",
+    program_id: "4UG",
+    yip: 4,
+    email: "simps@mail.com",
+    phone: "4165558888",
+    address: "100 Jameson Ave Toronto, ON M65-48H")
+  end
+
+  let(:application) do
+    applicant.applications.create!(
+      app_id: "1",
+      round_id: "110",
+      ta_training: "N",
+      access_acad_history: "Y",
+      ta_experience: "CSC373H1S (2), CSC318H1S (5), CSC423H5S (4), CSC324H1S (9), CSC404H1S (8)",
+      academic_qualifications: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eget dignissim sem. Curabitur at semper eros. Aenean nec sem lobortis, scelerisque mi at, aliquam diam. Mauris malesuada elit nibh, sed hendrerit nulla mattis sed. Mauris laoreet imperdiet dictum. Pellentesque risus nulla, varius ut massa ut, venenatis fringilla sapien. Cras eget euismod augue, eget dignissim erat. Cras nec nibh ullamcorper ante rutrum dapibus sed nec tellus. In hac habitasse platea dictumst. Suspendisse semper tellus ac sem tincidunt auctor.",
+      technical_skills: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eget dignissim sem. Curabitur at semper eros. Aenean nec sem lobortis, scelerisque mi at, aliquam diam. Mauris malesuada elit nibh, sed hendrerit nulla mattis sed. Mauris laoreet imperdiet dictum. Pellentesque risus nulla, varius ut massa ut, venenatis fringilla sapien. Cras eget euismod augue, eget dignissim erat. Cras nec nibh ullamcorper ante rutrum dapibus sed nec tellus. In hac habitasse platea dictumst. Suspendisse semper tellus ac sem tincidunt auctor.",
+      availability: "MW 9-8, RF 12-7",
+      other_info: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eget dignissim sem. Curabitur at semper eros. Aenean nec sem lobortis, scelerisque mi at, aliquam diam. Mauris malesuada elit nibh, sed hendrerit nulla mattis sed. Mauris laoreet imperdiet dictum. Pellentesque risus nulla, varius ut massa ut, venenatis fringilla sapien. Cras eget euismod augue, eget dignissim erat. Cras nec nibh ullamcorper ante rutrum dapibus sed nec tellus. In hac habitasse platea dictumst. Suspendisse semper tellus ac sem tincidunt auctor.",
+      special_needs: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eget dignissim sem. Curabitur at semper eros. Aenean nec sem lobortis, scelerisque mi at, aliquam diam. Mauris malesuada elit nibh, sed hendrerit nulla mattis sed. Mauris laoreet imperdiet dictum. Pellentesque risus nulla, varius ut massa ut, venenatis fringilla sapien. Cras eget euismod augue, eget dignissim erat. Cras nec nibh ullamcorper ante rutrum dapibus sed nec tellus. In hac habitasse platea dictumst. Suspendisse semper tellus ac sem tincidunt auctor."
+      )
+  end
+
+  context "when round_id is invalid" do
+    let (:response) { exporter.export(1) }
+    it "return generated false and an error message" do
+      expect(response).to eq({generated: false, msg: "Error: Invalid round_id"})
+    end
+  end
+
+  context "when round_id is valid" do
+    context "and there are no assignments" do
+      let (:response) { exporter.export(110) }
+
+      it "returns generated false and an error message" do
+        expect(response).to eq ({generated: false,
+          msg: "Warning: You have not made any assignments. Operation aborted."})
+      end
+    end
+
+    context "and there are assignments" do
+      before(:each) do
+        @assignment= applicant.assignments.create!(
+            position_id: position.id,
+            hours: 50
+        )
+        @data= [{
+          app_id: application[:app_id],
+          course_id: position[:position],
+          hours: @assignment[:hours],
+          round_id: 110.to_s,
+          utorid: applicant[:utorid],
+          name: "#{applicant[:first_name]} #{applicant[:last_name]}"
+        }]
+      end
+      let (:response) { exporter.export(110) }
+
+      it "returns generated true and data of all assignments in :round_id" do
+        expect(response).to eq ({generated: true, data: @data,
+          file: "offers_#{position[:round_id]}.json"})
+      end
+    end
+
+  end
+
+end

--- a/spec/services/chass_exporter_spec.rb
+++ b/spec/services/chass_exporter_spec.rb
@@ -4,7 +4,7 @@ describe ChassExporter do
   let (:exporter) { ChassExporter.new }
   let(:position) do
     Position.create!(
-    position: "CSC411",
+    position: "CSC411 - test 2",
     round_id: "110",
     open: true,
     campus_code: 1,
@@ -18,22 +18,21 @@ describe ChassExporter do
     )
   end
 
-  let(:applicant) do
-    Applicant.create!(
-    utorid: "cookie222",
-    student_number: 1234567890,
-    first_name: "Landy",
-    last_name: "Simpson",
-    dept: "Computer Science",
-    program_id: "4UG",
-    yip: 4,
-    email: "simps@mail.com",
-    phone: "4165558888",
-    address: "100 Jameson Ave Toronto, ON M65-48H")
-  end
+  before(:each) do
+    @applicant = Applicant.create!(
+      utorid: "cookie222",
+      student_number: 1234567890,
+      first_name: "Landy",
+      last_name: "Simpson",
+      dept: "Computer Science",
+      program_id: "4UG",
+      yip: 4,
+      email: "simps@mail.com",
+      phone: "4165558888",
+      address: "100 Jameson Ave Toronto, ON M65-48H"
+    )
 
-  let(:application) do
-    applicant.applications.create!(
+    @application = @applicant.applications.create!(
       app_id: "1",
       round_id: "110",
       ta_training: "N",
@@ -56,7 +55,7 @@ describe ChassExporter do
 
   context "when round_id is valid" do
     context "and there are no assignments" do
-      let (:response) { exporter.export(110) }
+      let (:response) { exporter.export(position[:round_id]) }
 
       it "returns generated false and an error message" do
         expect(response).to eq ({generated: false,
@@ -66,23 +65,23 @@ describe ChassExporter do
 
     context "and there are assignments" do
       before(:each) do
-        @assignment= applicant.assignments.create!(
+        @assignment= @applicant.assignments.create!(
             position_id: position.id,
             hours: 50
         )
         @data= [{
-          app_id: application[:app_id],
+          app_id: @application[:app_id],
           course_id: position[:position],
           hours: @assignment[:hours],
-          round_id: 110.to_s,
-          utorid: applicant[:utorid],
-          name: "#{applicant[:first_name]} #{applicant[:last_name]}"
+          round_id: position[:round_id].to_s,
+          utorid: @applicant[:utorid],
+          name: "#{@applicant[:first_name]} #{@applicant[:last_name]}"
         }]
       end
-      let (:response) { exporter.export(110) }
+      let (:response) { exporter.export(position[:round_id]) }
 
       it "returns generated true and data of all assignments in :round_id" do
-        expect(response).to eq ({generated: true, data: @data,
+        expect(response).to eq ({generated: true, data: @data, type: "application/json",
           file: "offers_#{position[:round_id]}.json"})
       end
     end

--- a/spec/services/chass_exporter_spec.rb
+++ b/spec/services/chass_exporter_spec.rb
@@ -47,18 +47,18 @@ describe ChassExporter do
   end
 
   context "when round_id is invalid" do
-    let (:response) { exporter.export(1) }
+    subject { exporter.export(1) }
     it "return generated false and an error message" do
-      expect(response).to eq({generated: false, msg: "Error: Invalid round_id"})
+      expect(subject).to eq({generated: false, msg: "Error: Invalid round_id"})
     end
   end
 
   context "when round_id is valid" do
     context "and there are no assignments" do
-      let (:response) { exporter.export(position[:round_id]) }
+      subject { exporter.export(position[:round_id]) }
 
       it "returns generated false and an error message" do
-        expect(response).to eq ({generated: false,
+        expect(subject).to eq ({generated: false,
           msg: "Warning: You have not made any assignments. Operation aborted."})
       end
     end
@@ -78,10 +78,10 @@ describe ChassExporter do
           name: "#{@applicant[:first_name]} #{@applicant[:last_name]}"
         }]
       end
-      let (:response) { exporter.export(position[:round_id]) }
+      subject { exporter.export(position[:round_id]) }
 
       it "returns generated true and data of all assignments in :round_id" do
-        expect(response).to eq ({generated: true, data: @data, type: "application/json",
+        expect(subject).to eq ({generated: true, data: @data, type: "application/json",
           file: "offers_#{position[:round_id]}.json"})
       end
     end

--- a/spec/services/csv_generator_spec.rb
+++ b/spec/services/csv_generator_spec.rb
@@ -1,5 +1,237 @@
 require 'rails_helper'
+require 'csv'
 
 describe CSVGenerator do
-  
+  let (:generator) { CSVGenerator.new }
+  let(:position) do
+    Position.create!(
+    position: "CSC411",
+    round_id: "110",
+    open: true,
+    campus_code: 1,
+    course_name: "Introduction to Software Testing",
+    estimated_enrolment: 50,
+    duties: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eget dignissim sem. Curabitur at semper eros. Aenean nec sem lobortis, scelerisque mi at, aliquam diam. Mauris malesuada elit nibh, sed hendrerit nulla mattis sed. Mauris laoreet imperdiet dictum. Pellentesque risus nulla, varius ut massa ut, venenatis fringilla sapien. Cras eget euismod augue, eget dignissim erat. Cras nec nibh ullamcorper ante rutrum dapibus sed nec tellus. In hac habitasse platea dictumst. Suspendisse semper tellus ac sem tincidunt auctor.",
+    qualifications: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eget dignissim sem. Curabitur at semper eros. Aenean nec sem lobortis, scelerisque mi at, aliquam diam. Mauris malesuada elit nibh, sed hendrerit nulla mattis sed. Mauris laoreet imperdiet dictum. Pellentesque risus nulla, varius ut massa ut, venenatis fringilla sapien. Cras eget euismod augue, eget dignissim erat. Cras nec nibh ullamcorper ante rutrum dapibus sed nec tellus. In hac habitasse platea dictumst. Suspendisse semper tellus ac sem tincidunt auctor.",
+    hours: 22,
+    estimated_count: 15,
+    estimated_total_hours: 330
+    )
+  end
+
+  context "when generating cdf_info" do
+    let(:applicant) do
+      Applicant.create!(
+      utorid: "cookie222",
+      student_number: 1234567890,
+      first_name: "Landy",
+      last_name: "Simpson",
+      dept: "Computer Science",
+      program_id: "4UG",
+      yip: 4,
+      email: "simps@mail.com",
+      phone: "4165558888",
+      address: "100 Jameson Ave Toronto, ON M65-48H")
+    end
+
+    let(:application) do
+      applicant.applications.create!(
+        app_id: "1",
+        round_id: "110",
+        ta_training: "N",
+        access_acad_history: "Y",
+        ta_experience: "CSC373H1S (2), CSC318H1S (5), CSC423H5S (4), CSC324H1S (9), CSC404H1S (8)",
+        academic_qualifications: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eget dignissim sem. Curabitur at semper eros. Aenean nec sem lobortis, scelerisque mi at, aliquam diam. Mauris malesuada elit nibh, sed hendrerit nulla mattis sed. Mauris laoreet imperdiet dictum. Pellentesque risus nulla, varius ut massa ut, venenatis fringilla sapien. Cras eget euismod augue, eget dignissim erat. Cras nec nibh ullamcorper ante rutrum dapibus sed nec tellus. In hac habitasse platea dictumst. Suspendisse semper tellus ac sem tincidunt auctor.",
+        technical_skills: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eget dignissim sem. Curabitur at semper eros. Aenean nec sem lobortis, scelerisque mi at, aliquam diam. Mauris malesuada elit nibh, sed hendrerit nulla mattis sed. Mauris laoreet imperdiet dictum. Pellentesque risus nulla, varius ut massa ut, venenatis fringilla sapien. Cras eget euismod augue, eget dignissim erat. Cras nec nibh ullamcorper ante rutrum dapibus sed nec tellus. In hac habitasse platea dictumst. Suspendisse semper tellus ac sem tincidunt auctor.",
+        availability: "MW 9-8, RF 12-7",
+        other_info: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eget dignissim sem. Curabitur at semper eros. Aenean nec sem lobortis, scelerisque mi at, aliquam diam. Mauris malesuada elit nibh, sed hendrerit nulla mattis sed. Mauris laoreet imperdiet dictum. Pellentesque risus nulla, varius ut massa ut, venenatis fringilla sapien. Cras eget euismod augue, eget dignissim erat. Cras nec nibh ullamcorper ante rutrum dapibus sed nec tellus. In hac habitasse platea dictumst. Suspendisse semper tellus ac sem tincidunt auctor.",
+        special_needs: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eget dignissim sem. Curabitur at semper eros. Aenean nec sem lobortis, scelerisque mi at, aliquam diam. Mauris malesuada elit nibh, sed hendrerit nulla mattis sed. Mauris laoreet imperdiet dictum. Pellentesque risus nulla, varius ut massa ut, venenatis fringilla sapien. Cras eget euismod augue, eget dignissim erat. Cras nec nibh ullamcorper ante rutrum dapibus sed nec tellus. In hac habitasse platea dictumst. Suspendisse semper tellus ac sem tincidunt auctor."
+        )
+    end
+    context "when there are no assignments in the system" do
+      let (:response) { generator.generate_cdf_info }
+      it "return generated false and an error message" do
+        expect(response).to eq({generated: false,
+          msg: "Warning: You have not made any assignments yet. Operation aborted"})
+      end
+    end
+
+    context "when there are assignments in the system" do
+      before(:each) do
+        @assignment= applicant.assignments.create!(
+            position_id: position.id,
+            hours: 50
+        )
+        @data = CSV.generate do |csv|
+          csv << [
+            "course_code",
+            "email_address",
+            "studentnumber",
+            "familyname",
+            "givenname",
+            "student_department",
+            "utorid",
+          ]
+          csv << [
+            position[:position],
+            applicant[:email],
+            applicant[:student_number],
+            applicant[:last_name],
+            applicant[:first_name],
+            applicant[:dept],
+            applicant[:utorid]
+          ]
+        end
+      end
+      let (:response) { generator.generate_cdf_info }
+
+      it "returns generated true and data of all cdf info" do
+        expect(response).to eq ({generated: true, data: @data,
+          file: "cdf_info.csv"})
+      end
+    end
+  end
+
+  context "when generating offers" do
+    let(:applicant) do
+      Applicant.create!(
+      utorid: "cookie222",
+      student_number: 1234567890,
+      first_name: "Landy",
+      last_name: "Simpson",
+      dept: "Computer Science",
+      program_id: "4UG",
+      yip: 4,
+      email: "simps@mail.com",
+      phone: "4165558888",
+      address: "100 Jameson Ave Toronto, ON M65-48H")
+    end
+
+    let(:application) do
+      applicant.applications.create!(
+        app_id: "1",
+        round_id: "110",
+        ta_training: "N",
+        access_acad_history: "Y",
+        ta_experience: "CSC373H1S (2), CSC318H1S (5), CSC423H5S (4), CSC324H1S (9), CSC404H1S (8)",
+        academic_qualifications: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eget dignissim sem. Curabitur at semper eros. Aenean nec sem lobortis, scelerisque mi at, aliquam diam. Mauris malesuada elit nibh, sed hendrerit nulla mattis sed. Mauris laoreet imperdiet dictum. Pellentesque risus nulla, varius ut massa ut, venenatis fringilla sapien. Cras eget euismod augue, eget dignissim erat. Cras nec nibh ullamcorper ante rutrum dapibus sed nec tellus. In hac habitasse platea dictumst. Suspendisse semper tellus ac sem tincidunt auctor.",
+        technical_skills: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eget dignissim sem. Curabitur at semper eros. Aenean nec sem lobortis, scelerisque mi at, aliquam diam. Mauris malesuada elit nibh, sed hendrerit nulla mattis sed. Mauris laoreet imperdiet dictum. Pellentesque risus nulla, varius ut massa ut, venenatis fringilla sapien. Cras eget euismod augue, eget dignissim erat. Cras nec nibh ullamcorper ante rutrum dapibus sed nec tellus. In hac habitasse platea dictumst. Suspendisse semper tellus ac sem tincidunt auctor.",
+        availability: "MW 9-8, RF 12-7",
+        other_info: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eget dignissim sem. Curabitur at semper eros. Aenean nec sem lobortis, scelerisque mi at, aliquam diam. Mauris malesuada elit nibh, sed hendrerit nulla mattis sed. Mauris laoreet imperdiet dictum. Pellentesque risus nulla, varius ut massa ut, venenatis fringilla sapien. Cras eget euismod augue, eget dignissim erat. Cras nec nibh ullamcorper ante rutrum dapibus sed nec tellus. In hac habitasse platea dictumst. Suspendisse semper tellus ac sem tincidunt auctor.",
+        special_needs: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eget dignissim sem. Curabitur at semper eros. Aenean nec sem lobortis, scelerisque mi at, aliquam diam. Mauris malesuada elit nibh, sed hendrerit nulla mattis sed. Mauris laoreet imperdiet dictum. Pellentesque risus nulla, varius ut massa ut, venenatis fringilla sapien. Cras eget euismod augue, eget dignissim erat. Cras nec nibh ullamcorper ante rutrum dapibus sed nec tellus. In hac habitasse platea dictumst. Suspendisse semper tellus ac sem tincidunt auctor."
+        )
+    end
+
+    context "when there are no assignments in the system" do
+      let (:response) { generator.generate_offers }
+      it "return generated false and an error message" do
+        expect(response).to eq({generated: false,
+          msg: "Warning: You have not made any assignments yet. Operation aborted"})
+      end
+    end
+
+    context "when there are assignments in the system" do
+      before(:each) do
+        @assignment= applicant.assignments.create!(
+            position_id: position.id,
+            hours: 50
+        )
+        @data = CSV.generate do |csv|
+          csv << [
+            "course_code",
+            "course_title",
+            "offer_hours",
+            "student_number",
+            "familyname",
+            "givenname",
+            "student_status",
+            "student_department",
+            "email_address",
+            "round_id",
+          ]
+          csv << [
+            position[:position],
+            position[:course_name],
+            @assignment[:hours].to_s,
+            applicant[:student_number].to_s,
+            applicant[:last_name],
+            applicant[:first_name],
+            "Other",
+            applicant[:dept],
+            applicant[:email],
+            position[:round_id].to_s,
+          ]
+        end
+      end
+      let (:response) { generator.generate_offers }
+
+      it "returns generated true and data of all cdf info" do
+        expect(response).to eq ({generated: true, data: @data,
+          file: "offers.csv"})
+      end
+    end
+  end
+
+  context "when generating transcript_access" do
+    context "when there are no applicants in the system" do
+      let (:response) { generator.generate_transcript_access }
+      it "return generated false and an error message" do
+        expect(response).to eq({generated: false,
+          msg: "Warning: There are currenly no applicant in the system. Operation aborted"})
+      end
+    end
+
+    context "when there are applicants in the system" do
+      before(:each) do
+        @applicant= Applicant.create!(
+          utorid: "cookie222",
+          student_number: 1234567890,
+          first_name: "Landy",
+          last_name: "Simpson",
+          dept: "Computer Science",
+          program_id: "4UG",
+          yip: 4,
+          email: "simps@mail.com",
+          phone: "4165558888",
+          address: "100 Jameson Ave Toronto, ON M65-48H"
+        )
+        @application = @applicant.applications.create!(
+          app_id: "1",
+          round_id: "110",
+          ta_training: "N",
+          access_acad_history: "Y",
+          ta_experience: "CSC373H1S (2), CSC318H1S (5), CSC423H5S (4), CSC324H1S (9), CSC404H1S (8)",
+          academic_qualifications: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eget dignissim sem. Curabitur at semper eros. Aenean nec sem lobortis, scelerisque mi at, aliquam diam. Mauris malesuada elit nibh, sed hendrerit nulla mattis sed. Mauris laoreet imperdiet dictum. Pellentesque risus nulla, varius ut massa ut, venenatis fringilla sapien. Cras eget euismod augue, eget dignissim erat. Cras nec nibh ullamcorper ante rutrum dapibus sed nec tellus. In hac habitasse platea dictumst. Suspendisse semper tellus ac sem tincidunt auctor.",
+          technical_skills: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eget dignissim sem. Curabitur at semper eros. Aenean nec sem lobortis, scelerisque mi at, aliquam diam. Mauris malesuada elit nibh, sed hendrerit nulla mattis sed. Mauris laoreet imperdiet dictum. Pellentesque risus nulla, varius ut massa ut, venenatis fringilla sapien. Cras eget euismod augue, eget dignissim erat. Cras nec nibh ullamcorper ante rutrum dapibus sed nec tellus. In hac habitasse platea dictumst. Suspendisse semper tellus ac sem tincidunt auctor.",
+          availability: "MW 9-8, RF 12-7",
+          other_info: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eget dignissim sem. Curabitur at semper eros. Aenean nec sem lobortis, scelerisque mi at, aliquam diam. Mauris malesuada elit nibh, sed hendrerit nulla mattis sed. Mauris laoreet imperdiet dictum. Pellentesque risus nulla, varius ut massa ut, venenatis fringilla sapien. Cras eget euismod augue, eget dignissim erat. Cras nec nibh ullamcorper ante rutrum dapibus sed nec tellus. In hac habitasse platea dictumst. Suspendisse semper tellus ac sem tincidunt auctor.",
+          special_needs: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eget dignissim sem. Curabitur at semper eros. Aenean nec sem lobortis, scelerisque mi at, aliquam diam. Mauris malesuada elit nibh, sed hendrerit nulla mattis sed. Mauris laoreet imperdiet dictum. Pellentesque risus nulla, varius ut massa ut, venenatis fringilla sapien. Cras eget euismod augue, eget dignissim erat. Cras nec nibh ullamcorper ante rutrum dapibus sed nec tellus. In hac habitasse platea dictumst. Suspendisse semper tellus ac sem tincidunt auctor."
+        )
+        @data = CSV.generate do |csv|
+          csv << [
+            "student_number",
+            "familyname",
+            "givenname",
+            "grant",
+            "email_address"
+          ]
+          csv << [
+            @applicant[:student_number],
+            @applicant[:last_name],
+            @applicant[:first_name],
+            @application[:access_acad_history].downcase,
+            @applicant[:email]
+          ]
+        end
+      end
+      let (:response) { generator.generate_transcript_access }
+
+      it "returns generated true and data of all cdf info" do
+        expect(response).to eq ({generated: true, data: @data,
+          file: "transcript_access.csv"})
+      end
+
+    end
+  end
+
 end

--- a/spec/services/csv_generator_spec.rb
+++ b/spec/services/csv_generator_spec.rb
@@ -5,7 +5,7 @@ describe CSVGenerator do
   let (:generator) { CSVGenerator.new }
   let(:position) do
     Position.create!(
-    position: "CSC411",
+    position: "CSC411 - test",
     round_id: "110",
     open: true,
     campus_code: 1,
@@ -36,7 +36,7 @@ describe CSVGenerator do
 
     let(:application) do
       applicant.applications.create!(
-        app_id: "1",
+        app_id: "15",
         round_id: "110",
         ta_training: "N",
         access_acad_history: "Y",
@@ -86,7 +86,7 @@ describe CSVGenerator do
       let (:response) { generator.generate_cdf_info }
 
       it "returns generated true and data of all cdf info" do
-        expect(response).to eq ({generated: true, data: @data,
+        expect(response).to eq ({generated: true, data: @data, type: "text/csv",
           file: "cdf_info.csv"})
       end
     end
@@ -166,7 +166,7 @@ describe CSVGenerator do
       let (:response) { generator.generate_offers }
 
       it "returns generated true and data of all cdf info" do
-        expect(response).to eq ({generated: true, data: @data,
+        expect(response).to eq ({generated: true, data: @data, type: "text/csv",
           file: "offers.csv"})
       end
     end
@@ -227,7 +227,7 @@ describe CSVGenerator do
       let (:response) { generator.generate_transcript_access }
 
       it "returns generated true and data of all cdf info" do
-        expect(response).to eq ({generated: true, data: @data,
+        expect(response).to eq ({generated: true, data: @data, type: "text/csv",
           file: "transcript_access.csv"})
       end
 

--- a/spec/services/csv_generator_spec.rb
+++ b/spec/services/csv_generator_spec.rb
@@ -49,9 +49,9 @@ describe CSVGenerator do
         )
     end
     context "when there are no assignments in the system" do
-      let (:response) { generator.generate_cdf_info }
+      subject { generator.generate_cdf_info }
       it "return generated false and an error message" do
-        expect(response).to eq({generated: false,
+        expect(subject).to eq({generated: false,
           msg: "Warning: You have not made any assignments. Operation aborted."})
       end
     end
@@ -83,10 +83,10 @@ describe CSVGenerator do
           ]
         end
       end
-      let (:response) { generator.generate_cdf_info }
+      subject { generator.generate_cdf_info }
 
       it "returns generated true and data of all cdf info" do
-        expect(response).to eq ({generated: true, data: @data, type: "text/csv",
+        expect(subject).to eq ({generated: true, data: @data, type: "text/csv",
           file: "cdf_info.csv"})
       end
     end
@@ -123,9 +123,9 @@ describe CSVGenerator do
     end
 
     context "when there are no assignments in the system" do
-      let (:response) { generator.generate_offers }
+      subject { generator.generate_offers }
       it "return generated false and an error message" do
-        expect(response).to eq({generated: false,
+        expect(subject).to eq({generated: false,
           msg: "Warning: You have not made any assignments. Operation aborted."})
       end
     end
@@ -163,10 +163,10 @@ describe CSVGenerator do
           ]
         end
       end
-      let (:response) { generator.generate_offers }
+      subject { generator.generate_offers }
 
       it "returns generated true and data of all cdf info" do
-        expect(response).to eq ({generated: true, data: @data, type: "text/csv",
+        expect(subject).to eq ({generated: true, data: @data, type: "text/csv",
           file: "offers.csv"})
       end
     end
@@ -174,9 +174,9 @@ describe CSVGenerator do
 
   context "when generating transcript_access" do
     context "when there are no applicants in the system" do
-      let (:response) { generator.generate_transcript_access }
+      subject { generator.generate_transcript_access }
       it "return generated false and an error message" do
-        expect(response).to eq({generated: false,
+        expect(subject).to eq({generated: false,
           msg: "Warning: There are currenly no applicant in the system. Operation aborted"})
       end
     end
@@ -224,10 +224,10 @@ describe CSVGenerator do
           ]
         end
       end
-      let (:response) { generator.generate_transcript_access }
+      subject { generator.generate_transcript_access }
 
       it "returns generated true and data of all cdf info" do
-        expect(response).to eq ({generated: true, data: @data, type: "text/csv",
+        expect(subject).to eq ({generated: true, data: @data, type: "text/csv",
           file: "transcript_access.csv"})
       end
 

--- a/spec/services/csv_generator_spec.rb
+++ b/spec/services/csv_generator_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+describe CSVGenerator do
+  
+end

--- a/spec/services/csv_generator_spec.rb
+++ b/spec/services/csv_generator_spec.rb
@@ -52,7 +52,7 @@ describe CSVGenerator do
       let (:response) { generator.generate_cdf_info }
       it "return generated false and an error message" do
         expect(response).to eq({generated: false,
-          msg: "Warning: You have not made any assignments yet. Operation aborted"})
+          msg: "Warning: You have not made any assignments. Operation aborted."})
       end
     end
 
@@ -126,7 +126,7 @@ describe CSVGenerator do
       let (:response) { generator.generate_offers }
       it "return generated false and an error message" do
         expect(response).to eq({generated: false,
-          msg: "Warning: You have not made any assignments yet. Operation aborted"})
+          msg: "Warning: You have not made any assignments. Operation aborted."})
       end
     end
 


### PR DESCRIPTION
The routes:
- `GET /export/chass/:round_id` downloads `export_data.json`
- `GET /export/cdf-info` downloads `cdf_info.csv`
- `GET /export/offers` downloads `offers.csv`
- `GET /export/transcript-access` downloads `transcript_access.csv`


- Added rspec for `ChassExporter`, `CSVGenerator` and `ExportController`