### PR TITLE
removed abc route with course param

### DIFF
--- a/app/javascript/app/components/assigned.js
+++ b/app/javascript/app/components/assigned.js
@@ -86,8 +86,7 @@ class Assigned extends React.Component {
                         {this.props.func.getAssignmentsByApplicant(p.applicantId).map(ass =>
                             <Link
                                 to={
-                                    'applicantsbycourse/' +
-                                    ass.positionId +
+                                    'applicantsbycourse' +
                                     '#' +
                                     ass.positionId +
                                     '-' +
@@ -95,7 +94,11 @@ class Assigned extends React.Component {
                                     '-1'
                                 }
                                 key={'link-' + p.applicantId + '-' + ass.positionId}>
-                                <Button bsSize="xsmall" style={{ borderColor: '#555' }}>
+                                <Button
+                                    bsSize="xsmall"
+                                    style={{ borderColor: '#555' }}
+                                    onClick={() =>
+                                        this.props.func.setSelectedCourses([ass.positionId])}>
                                     {this.props.func.getCourseCodeById(
                                         ass.positionId
                                     )}&nbsp;&middot;&nbsp;{ass.hours}

--- a/app/javascript/app/components/unassigned.js
+++ b/app/javascript/app/components/unassigned.js
@@ -86,8 +86,7 @@ class Unassigned extends React.Component {
                         {this.props.func.getApplicationById(p.applicantId).prefs.map(pref =>
                             <Link
                                 to={
-                                    'applicantsbycourse/' +
-                                    pref.positionId +
+                                    'applicantsbycourse' +
                                     '#' +
                                     pref.positionId +
                                     '-' +
@@ -95,7 +94,11 @@ class Unassigned extends React.Component {
                                     '-0'
                                 }
                                 key={'link-' + p.applicantId + '-' + pref.positionId}>
-                                <Button bsSize="xsmall" style={{ borderColor: '#555' }}>
+                                <Button
+                                    bsSize="xsmall"
+                                    style={{ borderColor: '#555' }}
+                                    onClick={() =>
+                                        this.props.func.setSelectedCourses([pref.positionId])}>
                                     {this.props.func.getCourseCodeById(pref.positionId)}
                                 </Button>
                             </Link>

--- a/app/javascript/packs/app.js
+++ b/app/javascript/packs/app.js
@@ -67,15 +67,6 @@ const RouterInst = props => {
                         render={() => <Courses navKey={routeConfig.courses.key} {...props} />}
                     />
                     <Route
-                        path={routeConfig.abc.route + '/:course'}
-                        render={({ match }) =>
-                            <ABC
-                                navKey={routeConfig.abc.key}
-                                selectedCourse={match.params.course}
-                                {...props}
-                            />}
-                    />
-                    <Route
                         path={routeConfig.abc.route}
                         render={() => <ABC navKey={routeConfig.abc.key} {...props} />}
                     />


### PR DESCRIPTION
The URL course param had to be handled in the ABC `componentWillMount`/`componentWillUpdate` methods: specifically, it had to be used to set the selected course in order to display that course on ABC render. However, this meant that, it would be set as the selected course every time the ABC view re-rendered, and so we could not change the selected courses within the view (unselect that course, for example).

Instead, the selected course is set in the Un/Assigned course buttons' `onClick` handler, as the ABC view is being rendered normally. 
I'm not sure if this could cause a race condition between rendering the view and running the click handler, but it shouldn't matter as long as the click handler runs eventually.