### PR TITLE
Fixed ABC view bug (primarily seen going b/w ABC, Assigned, and Unassigned)

### DIFF
--- a/app/javascript/app/appState.js
+++ b/app/javascript/app/appState.js
@@ -342,33 +342,7 @@ class AppState {
 
     // set the course panel layout in the ABC view
     setCoursePanelLayout(layout) {
-        let selected = this.getSelectedCourses();
-        let panelFields = this.getCoursePanelFields();
-
-        // check that panel state trackers exist for exactly the current courses
-        if (selected != Object.keys(panelFields)) {
-            for (var course in panelFields) {
-                // if a tracker is missing, create it (the course was just selected)
-                if (!selected.includes(course)) {
-                    delete panelFields[course];
-                }
-            }
-
-            for (var course = 0; course < selected.length; course++) {
-                // if a tracker is extra, remove it (the course was just unselected)
-                if (!(selected[course] in panelFields)) {
-                    panelFields[selected[course]] = {
-                        selectedSortFields: [],
-                        selectedFilters: {},
-                    };
-                }
-            }
-
-            this._data.unset('abcView.panelFields', { silent: true });
-            this._data.set({ 'abcView.panelLayout': layout, 'abcView.panelFields': panelFields });
-        } else {
-            this._data.set('abcView.panelLayout', layout);
-        }
+        this._data.set('abcView.panelLayout', layout);
     }
 
     setSelectedCourses(courses) {
@@ -518,6 +492,36 @@ class AppState {
     // unselect the applicant displayed in the applicant view
     unselectApplicant() {
         this._data.unset('selectedApplicant');
+    }
+
+    // check whether a panelFields object exists for each of the currently selected courses
+    // if not, create the appropriate panelFields
+    updateCoursePanelFields(selected, panelFields) {
+        let update = false;
+
+        for (var course in panelFields) {
+            // if a tracker is extra, remove it (the course was just unselected)
+            if (!selected.includes(parseInt(course))) {
+                delete panelFields[course];
+                update = true;
+            }
+        }
+
+        for (var course = 0; course < selected.length; course++) {
+            // if a tracker is missing, create it (the course was just selected)
+            if (!(selected[course] in panelFields)) {
+                panelFields[selected[course]] = {
+                    selectedSortFields: [],
+                    selectedFilters: {},
+                };
+                update = true;
+            }
+        }
+
+        if (update) {
+            this._data.unset('abcView.panelFields', { silent: true });
+            this._data.set('abcView.panelFields', panelFields);
+        }
     }
 
     /******************************

--- a/app/javascript/app/components/abc.js
+++ b/app/javascript/app/components/abc.js
@@ -86,6 +86,10 @@ class ABC extends React.Component {
         if (Math.floor(currLayout) != selected.length) {
             this.props.func.setCoursePanelLayout(selected.length);
         }
+
+        let panelFields = this.props.func.getCoursePanelFields();
+        // check whether the appropriate panel fields exist for the selected courses and update as necessary
+        this.props.func.updateCoursePanelFields(selected, panelFields);
     }
 
     selectThisTab() {


### PR DESCRIPTION
Fixed ABC view bug in which we were checking whether the current course panel layout was appropriate for the new number of panels - but we were not checking whether the appropriate panelFields object existed for the currently selected courses.

This meant that, if we had a layout with 1 course open, then tried to open a layout with another single course, the latter course would not have a corresponding panelFields object. (For example, if we opened a course through the Assigned view, then went back to the Assigned view and tried to open a different course).