### PR TITLE
Round filtering for individual rounds

### DIFF
--- a/app/javascript/app/appState.js
+++ b/app/javascript/app/appState.js
@@ -222,6 +222,18 @@ class AppState {
         }
     }
 
+    // remove currently-selected courses that are not part of the currently-selected round
+    filterSelectedCourses() {
+        let selected = this.get('abcView.selectedCourses'),
+            courses = this.getCoursesList();
+
+        let newSelected = selected.filter(course => courses.has(course));
+
+        if (selected.size != newSelected.size) {
+            this.set('abcView.selectedCourses', newSelected);
+        }
+    }
+
     getAlerts() {
         return this.get('alerts');
     }
@@ -517,8 +529,9 @@ class AppState {
 
     // check whether a panelFields object exists for each of the currently selected courses
     // if not, create the appropriate panelFields
-    updateCoursePanelFields(selected) {
-        let panelFields = this.get('abcView.panelFields'),
+    updateCoursePanelFields() {
+        let selected = this.get('abcView.selectedCourses'),
+            panelFields = this.get('abcView.panelFields'),
             missingCourses = [];
 
         for (var course of selected.values()) {

--- a/app/javascript/app/appState.js
+++ b/app/javascript/app/appState.js
@@ -372,15 +372,15 @@ class AppState {
         this.set('selectedRound', round);
     }
 
-    // set the course panel layout in the ABC view
-    setCoursePanelLayout(layout) {
-        this.set('abcView.panelLayout', layout);
-    }
-
     selectSingleCourse(course) {
         // Note: toString() is a hack because our components think that course IDs are numbers but Immutable
         // thinks they are strings
         this.set('abcView.selectedCourses', fromJS([course.toString()]));
+    }
+
+    // set the course panel layout in the ABC view
+    setCoursePanelLayout(layout) {
+        this.set('abcView.panelLayout', layout);
     }
 
     // change the number of hours of a temporary assignment

--- a/app/javascript/app/appState.js
+++ b/app/javascript/app/appState.js
@@ -779,15 +779,17 @@ class AppState {
         return applications.map((_, applicant) => applicants.get(applicant)).entrySeq();
     }
 
-    /*** NEEDS UPDATING WITH ROUNDS ***/
     getApplicationById(applicant) {
-        return this.get('applications.list.' + applicant + '[0]');
+        // applications should already be filtered by round, so the applicant should only have
+        // one application
+        return this.get('applications.list').get(applicant).first();
     }
 
-    /*** NEEDS UPDATING WITH ROUNDS ***/
     // check whether this course is a preference for this applicant
     getApplicationPreference(applicant, course) {
-        let prefs = this.get('applications.list.' + applicant + '[0].prefs');
+        // applications should already be filtered by round, so the applicant should only have
+        // one application
+        let prefs = this.get('applications.list').get(applicant).first().get('prefs');
 
         return prefs.some(pref => pref.get('positionId') == course && pref.get('preferred'));
     }

--- a/app/javascript/app/appState.js
+++ b/app/javascript/app/appState.js
@@ -22,6 +22,9 @@ const initialState = {
     // applicant to display in applicant view
     selectedApplicant: null,
 
+    // application round to display
+    selectedRound: null,
+
     // ABC view
     abcView: {
         selectedCourses: [],
@@ -264,6 +267,10 @@ class AppState {
         return this.get('nav.selectedTab');
     }
 
+    getSelectedRound() {
+        return this.get('selectedRound');
+    }
+
     // return the name of the appState component that corresponds to the currently selected view
     getSelectedViewStateComponent() {
         switch (this.get('nav.selectedTab')) {
@@ -358,6 +365,11 @@ class AppState {
     // select a navbar tab
     selectNavTab(eventKey) {
         this.set('nav.selectedTab', eventKey);
+    }
+
+    // select a round to display
+    selectRound(round) {
+        this.set('selectedRound', round);
     }
 
     // set the course panel layout in the ABC view
@@ -727,7 +739,7 @@ class AppState {
         return this.get('courses.list.' + course);
     }
 
-    // return a sorted list of course codes
+    // get a sorted list of course codes
     getCourseCodes() {
         return this.get('courses.list').valueSeq().map(course => course.get('code')).sort();
     }
@@ -738,6 +750,11 @@ class AppState {
 
     getInstructorsList() {
         return this.get('instructors.list');
+    }
+
+    // get a list of all rounds for all courses
+    getRounds() {
+        return this.get('courses.list').map(course => course.get('round')).flip().keySeq();
     }
 
     // get all applicants who have not been assigned to a course; returns a list of [applicantID, applicantData]

--- a/app/javascript/app/appState.js
+++ b/app/javascript/app/appState.js
@@ -860,7 +860,7 @@ class AppState {
 
     // get a list of all rounds for all courses
     getRounds() {
-        return this.get('courses.list').map(course => course.get('round')).flip().keySeq();
+        return this.get('courses').get('list').map(course => course.get('round')).flip().keySeq();
     }
 
     // get all applicants who have not been assigned to a course; returns a list of [applicantID, applicantData]

--- a/app/javascript/app/appState.js
+++ b/app/javascript/app/appState.js
@@ -635,7 +635,9 @@ class AppState {
     }
 
     getApplicantById(applicant) {
-        return this.getApplicantsList().get(applicant);
+        // Note: toString() is a hack because our components think that course IDs are numbers but Immutable
+        // thinks they are strings
+        return this.getApplicantsList().get(applicant.toString());
     }
 
     getApplicantsInSelectedRound() {
@@ -691,14 +693,18 @@ class AppState {
     getApplicationById(applicant) {
         // applications should already be filtered by round, so the applicant should only have
         // one application
-        return this.getApplicationsList().get(applicant).first();
+        // Note: toString() is a hack because our components think that course IDs are numbers but Immutable
+        // thinks they are strings
+        return this.getApplicationsList().get(applicant.toString()).first();
     }
 
     // check whether this course is a preference for this applicant
     getApplicationPreference(applicant, course) {
         // applications should already be filtered by round, so the applicant should only have
         // one application
-        let prefs = this.getApplicationsList().get(applicant).first().get('prefs');
+        // Note: toString() is a hack because our components think that course IDs are numbers but Immutable
+        // thinks they are strings
+        let prefs = this.getApplicationsList().get(applicant.toString()).first().get('prefs');
 
         return prefs.some(pref => pref.get('positionId') == course && pref.get('preferred'));
     }
@@ -745,7 +751,9 @@ class AppState {
     }
 
     getAssignmentByApplicant(applicant, course) {
-        let assignments = this.getAssignmentsList().get(applicant);
+        // Note: toString() is a hack because our components think that course IDs are numbers but Immutable
+        // thinks they are strings
+        let assignments = this.getAssignmentsList().get(applicant.toString());
 
         if (assignments) {
             return assignments.find(ass => ass.get('positionId') == course);
@@ -755,7 +763,9 @@ class AppState {
     }
 
     getAssignmentsByApplicant(applicant) {
-        let assignments = this.getAssignmentsList().get(applicant);
+        // Note: toString() is a hack because our components think that course IDs are numbers but Immutable
+        // thinks they are strings
+        let assignments = this.getAssignmentsList().get(applicant.toString());
 
         if (assignments) {
             return assignments;
@@ -774,6 +784,8 @@ class AppState {
                 assignments
                     .map(
                         // filter out assignments where the course is in the selected round
+                        // Note: toString() is a hack because our components think that course IDs are
+                        // numbers but Immutable thinks they are strings
                         applicant =>
                             applicant.filter(assignment =>
                                 courses.has(assignment.get('positionId').toString())
@@ -800,7 +812,9 @@ class AppState {
     }
 
     getCourseById(course) {
-        return this.getCoursesList().get(course);
+        // Note: toString() is a hack because our components think that course IDs are numbers but Immutable
+        // thinks they are strings
+        return this.getCoursesList().get(course.toString());
     }
 
     // get a sorted list of course codes
@@ -809,7 +823,9 @@ class AppState {
     }
 
     getCourseCodeById(course) {
-        return this.getCoursesList().get(course + '.code');
+        // Note: toString() is a hack because our components think that course IDs are numbers but Immutable
+        // thinks they are strings
+        return this.getCoursesList().get(course.toString()).get('code');
     }
 
     getCoursesInSelectedRound() {
@@ -892,7 +908,9 @@ class AppState {
     }
 
     removeInstructor(courseId, index) {
-        let val = this.getCoursesList().get(courseId + '.instructors').toJS();
+        // Note: toString() is a hack because our components think that course IDs are numbers but Immutable
+        // thinks they are strings
+        let val = this.getCoursesList().get(courseId.toString()).get('instructors').toJS();
         val.splice(index, 1);
         fetch.updateCourse(courseId, { instructors: val }, 'instructors');
     }

--- a/app/javascript/app/appState.js
+++ b/app/javascript/app/appState.js
@@ -91,7 +91,24 @@ class AppState {
 
         // getter for appState object
         this.get = function(property) {
-            return _data.getIn(parsePath(property));
+            let result = _data.getIn(parsePath(property));
+
+            // apply round-based filters
+            switch (property) {
+                case 'applicants.list':
+                    return this.getApplicantsInSelectedRound(result);
+
+                case 'applications.list':
+                    return this.getApplicationsInSelectedRound(result);
+
+                case 'assignments.list':
+                    return this.getAssignmentsInSelectedRound(result);
+
+                case 'courses.list':
+                    return this.getCoursesInSelectedRound(result);
+            }
+
+            return result;
         };
 
         // setters for appState object
@@ -579,6 +596,81 @@ class AppState {
         ].some(val => val == null);
     }
 
+    getApplicantsInSelectedRound(applicants) {
+        let round = this.get('selectedRound'),
+            applications = this.get('applications.list');
+
+        if (round && applicants) {
+            // list of applications should already be filtered by round
+            return applicants.filter((_, id) => applications.has(id));
+        } else {
+            // all rounds displayed and/or no applicants exist
+            return applicants;
+        }
+    }
+
+    getApplicationsInSelectedRound(applications) {
+        let round = this.get('selectedRound'),
+            courses = this.get('courses.list'); // list of courses should already be filtered by round
+
+        if (round && applications) {
+            return (
+                applications
+                    .map(applicant =>
+                        applicant.filter(
+                            // filter out applications where at least one course was applied for, and the first course
+                            // applied to is in the selected round
+                            // note: this assumes that, if all courses in the application are in the same round
+                            application =>
+                                application.get('prefs').size == 0 ||
+                                courses.has(
+                                    application.get('prefs').first().get('positionId').toString()
+                                )
+                        )
+                    )
+                    // filter out applicants who have no applications in the selected round
+                    .filter(applicant => applicant.size > 0)
+            );
+        } else {
+            // all rounds displayed and/or no applications exist
+            return applications;
+        }
+    }
+
+    getAssignmentsInSelectedRound(assignments) {
+        let round = this.get('selectedRound'),
+            courses = this.get('courses.list'); // list of courses should already be filtered by round
+
+        if (round && assignments) {
+            return (
+                assignments
+                    .map(
+                        // filter out assignments where the course is in the selected round
+                        applicant =>
+                            applicant.filter(assignment =>
+                                courses.has(assignment.get('positionId').toString())
+                            )
+                    )
+                    // filter out applicants who have no assignments to course(s) in the selected round
+                    .filter(applicant => applicant.size > 0)
+            );
+        } else {
+            // all rounds displayed and/or no assignments exist
+            return assignments;
+        }
+    }
+
+    getCoursesInSelectedRound(courses) {
+        let round = this.get('selectedRound');
+
+        if (round && courses) {
+            return courses.filter(course => course.get('round') == round);
+        } else {
+            // all rounds displayed and/or no courses exist
+            return courses;
+        }
+    }
+
     // create a new assignment
     createAssignment(applicant, course, hours) {
         fetch.postAssignment(applicant, course, hours);
@@ -618,6 +710,18 @@ class AppState {
     // check if instructors are being fetched
     fetchingInstructors() {
         return this.get('instructors.fetching') > 0;
+    }
+
+    filterApplicantsByRound() {
+        let round = this.get('selectedRound'),
+            applicants = this.get('applicants.list'),
+            applications = this.get('applications.list');
+
+        if (round) {
+        } else {
+            // all rounds displayed, so return the entire list
+            return this.get('applicants.list');
+        }
     }
 
     // get applicants who are assigned to course; returns a list of [applicantID, applicantData]

--- a/app/javascript/app/appState.js
+++ b/app/javascript/app/appState.js
@@ -602,10 +602,9 @@ class AppState {
         fetch.deleteAssignment(applicant, assignment);
     }
 
-    /*** NEEDS UPDATING WITH ROUNDS ***/
     // export current assignments
     exportOffers() {
-        fetch.exportOffers(110);
+        fetch.exportOffers(this.get('selectedRound'));
     }
 
     // check if applicants are being fetched

--- a/app/javascript/app/components/abc.js
+++ b/app/javascript/app/components/abc.js
@@ -86,9 +86,6 @@ class ABC extends React.Component {
         if (Math.floor(currLayout) != selected.length) {
             this.props.setCoursePanelLayout(selected.length);
         }
-
-        // check whether the appropriate panel fields exist for the selected courses and update as necessary
-        this.props.updateCoursePanelFields(selected);
     }
 
     selectThisTab() {
@@ -100,15 +97,27 @@ class ABC extends React.Component {
     componentWillMount() {
         this.selectThisTab();
 
+        // remove selected courses that are not part of the selected round if necessary
+        this.props.filterSelectedCourses();
+
         // generate a default layout for the selected courses if necessary
         this.generateDefaultLayout();
+
+        // check whether the appropriate panel fields exist for the selected courses and update if necessary
+        this.props.updateCoursePanelFields();
     }
 
     componentWillUpdate() {
         this.selectThisTab();
 
+        // remove selected courses that are not part of the selected round if necessary
+        this.props.filterSelectedCourses();
+
         // generate a default layout for the selected courses if necessary
         this.generateDefaultLayout();
+
+        // check whether the appropriate panel fields exist for the selected courses and update if necessary
+        this.props.updateCoursePanelFields();
     }
 
     render() {

--- a/app/javascript/app/components/abc.js
+++ b/app/javascript/app/components/abc.js
@@ -100,30 +100,12 @@ class ABC extends React.Component {
     componentWillMount() {
         this.selectThisTab();
 
-        // render this view with a specific course panel pre-selected
-        let selected = this.props.getSelectedCourses();
-        if (
-            this.props.selectedCourse &&
-            !(selected.length == 1 && selected[0] == this.props.selectedCourse)
-        ) {
-            this.props.setSelectedCourses([this.props.selectedCourse]);
-        }
-
         // generate a default layout for the selected courses if necessary
         this.generateDefaultLayout();
     }
 
     componentWillUpdate() {
         this.selectThisTab();
-
-        // render this view with a specific course panel pre-selected
-        let selected = this.props.getSelectedCourses();
-        if (
-            this.props.selectedCourse &&
-            !(selected.length == 1 && selected[0] == this.props.selectedCourse)
-        ) {
-            this.props.setSelectedCourses([this.props.selectedCourse]);
-        }
 
         // generate a default layout for the selected courses if necessary
         this.generateDefaultLayout();

--- a/app/javascript/app/components/navbar.js
+++ b/app/javascript/app/components/navbar.js
@@ -94,6 +94,12 @@ const Round = props => {
         return null;
     }
 
+    // colours which will be mapped to rounds
+    // (approx. one colour selected from each colour group on https://www.w3schools.com/colors/colors_groups.asp)
+    let palette = ['#C71585','#4B0082','#8B0000','#FF4500','#006400','#008080','000080','#0000FF',
+                   '#8B4513','#2F4F4F'];
+    
+    let rounds = props.getRounds();
     let selectedRound = props.getSelectedRound();
 
     return (
@@ -102,7 +108,7 @@ const Round = props => {
                 <span
                     style={{
                         color: '#fff',
-                        backgroundColor: '#5bc0de',
+                        backgroundColor: selectedRound ? palette[rounds.indexOf(selectedRound)] : '#5BC0DE',
                         padding: '6px 12px',
                         borderRadius: '4px',
                     }}>
@@ -116,7 +122,7 @@ const Round = props => {
                 <MenuItem eventKey={null} key="all">
                     All Rounds
                 </MenuItem>}
-            {props.getRounds().map(
+            {rounds.map(
                 round =>
                     round != selectedRound &&
                     <MenuItem eventKey={round} key={round}>

--- a/app/javascript/app/components/navbar.js
+++ b/app/javascript/app/components/navbar.js
@@ -94,21 +94,38 @@ const Round = props => {
         return null;
     }
 
+    let rounds = props.getRounds();
+    let selectedRound = props.getSelectedRound();
+
+    // add round-based rules to a new stylesheet
+    let style = document.createElement('style');
+
+    // if we previously created a stylesheet for these rules, replace it
+    let oldStyle = document.getElementsByTagName('style');
+    if (oldStyle.length > 0) {
+        document.head.replaceChild(style, oldStyle[0]);
+    } else {
+        document.head.appendChild(style);
+    }
+
     // colours which will be mapped to rounds
     // (approx. one colour selected from each colour group on https://www.w3schools.com/colors/colors_groups.asp)
     let palette = ['#C71585','#4B0082','#8B0000','#FF4500','#006400','#008080','000080','#0000FF',
                    '#8B4513','#2F4F4F'];
+
+    style.sheet.insertRule('.round-all {background-color: #5BC0DE}', 0);
     
-    let rounds = props.getRounds();
-    let selectedRound = props.getSelectedRound();
+    for (var i = 0; i < rounds.length; i++) {
+        style.sheet.insertRule('.round-' + rounds[i] + ' {background-color: ' + palette[i] + '}', 0);
+    }
 
     return (
         <NavDropdown
             title={
                 <span
+                    className={'round-' + (selectedRound ? selectedRound : 'all')}
                     style={{
                         color: '#fff',
-                        backgroundColor: selectedRound ? palette[rounds.indexOf(selectedRound)] : '#5BC0DE',
                         padding: '6px 12px',
                         borderRadius: '4px',
                     }}>

--- a/app/javascript/app/components/navbar.js
+++ b/app/javascript/app/components/navbar.js
@@ -90,7 +90,7 @@ const CoursePanelLayoutTabs = props => {
 };
 
 const Round = props => {
-    if (props.isCoursesListNull() || props.fetchingCourses()) {
+    if (props.isCoursesListNull()) {
         return null;
     }
 

--- a/app/javascript/app/components/navbar.js
+++ b/app/javascript/app/components/navbar.js
@@ -89,6 +89,44 @@ const CoursePanelLayoutTabs = props => {
     return null;
 };
 
+const Round = props => {
+    if (props.isCoursesListNull() || props.fetchingCourses()) {
+        return null;
+    }
+
+    let selectedRound = props.getSelectedRound();
+
+    return (
+        <NavDropdown
+            title={
+                <span
+                    style={{
+                        color: '#fff',
+                        backgroundColor: '#5bc0de',
+                        padding: '6px 12px',
+                        borderRadius: '4px',
+                    }}>
+                    {selectedRound ? 'Round ' + selectedRound : 'All Rounds'}
+                </span>
+            }
+            noCaret
+            id="nav-round-dropdown"
+            onSelect={eventKey => props.selectRound(eventKey)}>
+            {selectedRound &&
+                <MenuItem eventKey={null} key="all">
+                    All Rounds
+                </MenuItem>}
+            {props.getRounds().map(
+                round =>
+                    round != selectedRound &&
+                    <MenuItem eventKey={round} key={round}>
+                        Round {round}
+                    </MenuItem>
+            )}
+        </NavDropdown>
+    );
+};
+
 const Notifications = props => {
     let notifications = props.getUnreadNotifications();
 
@@ -114,38 +152,33 @@ const Notifications = props => {
     );
 };
 
-const Auth = props => {
-    return (
-        <NavDropdown
-            eventKey={routeConfig.logout.id}
-            title={props.getCurrentUserRole() + ':' + props.getCurrentUserName()}
-            id="nav-auth-dropdown">
-            <MenuItem eventKey={routeConfig.logout.id + '.1'} href={routeConfig.logout.route}>
-                Logout
-            </MenuItem>
-        </NavDropdown>
-    );
-};
+const Auth = props =>
+    <NavDropdown
+        eventKey={routeConfig.logout.id}
+        title={props.getCurrentUserRole() + ':' + props.getCurrentUserName()}
+        id="nav-auth-dropdown">
+        <MenuItem eventKey={routeConfig.logout.id + '.1'} href={routeConfig.logout.route}>
+            Logout
+        </MenuItem>
+    </NavDropdown>;
 
 /*** Navbar ***/
 
-const NavbarInst = props => {
-    return (
-        <Navbar fixedTop fluid>
-            <Navbar.Header>
-                <Navbar.Brand>TAPP</Navbar.Brand>
-            </Navbar.Header>
+const NavbarInst = props =>
+    <Navbar fixedTop fluid>
+        <Navbar.Header>
+            <Navbar.Brand>TAPP</Navbar.Brand>
+        </Navbar.Header>
 
-            <ViewTabs {...props} />
+        <ViewTabs {...props} />
 
-            <Nav pullRight>
-                {props.getSelectedNavTab() == routeConfig.abc.id &&
-                    <CoursePanelLayoutTabs {...props} />}
-                <Notifications {...props} />
-                <Auth {...props} />
-            </Nav>
-        </Navbar>
-    );
-};
+        <Nav pullRight>
+            {props.getSelectedNavTab() == routeConfig.abc.id &&
+                <CoursePanelLayoutTabs {...props} />}
+            <Round {...props} />
+            <Notifications {...props} />
+            <Auth {...props} />
+        </Nav>
+    </Navbar>;
 
 export { NavbarInst as Navbar };

--- a/app/javascript/app/components/summary.js
+++ b/app/javascript/app/components/summary.js
@@ -187,7 +187,7 @@ class ExportForm extends React.Component {
                             this.format = ref;
                         }}>
                         <option value="csv">CSV</option>
-                        <option value="json">JSON</option>
+                        {this.props.getSelectedRound() && <option value="json">JSON</option>}
                     </FormControl>
                 </FormGroup>
                 <FormControl.Static style={{ verticalAlign: 'middle' }}>


### PR DESCRIPTION
**To do:**
- [x] Fix issue with changing rounds in ABC view while a course is open that is not in the new round
- [x] When #138 is merged, update https://github.com/uoft-tapp/tapp/blob/5e9215d3529aa3fc4b3d44c99250e7e040878822/app/javascript/app/appState.js#L583

#### Note: we expect unspecified UI behaviour when all rounds are selected - this is not expected to work properly at this point

### Expected behaviour:
- navbar:
  - a button should appear in the navbar with the currently-selected round (or "All Rounds")
  - when the button is clicked, a drop-down menu should be displayed with a list of all rounds (other than the currently-selected round) and "All Rounds"
- Courses view: 
  - only courses in the currently-selected round should be displayed (in either the course list or main courses box)
- ABC view: 
  - only courses in the currently-selected round should be displayed in the course menu
  - when a course is selected, only applicants who applied to the course in the currently-selected round should be displayed (in either the assigned or unassigned list)
- Assigned view:
  - only applicants who have assignments to courses in the currently-selected round should be displayed in the table
  - for each applicant, only assignment(s) to courses in the currently-selected round should appear under "Course(s)"
- Assigned view:
  - only applicants who applied to courses in the currently-selected round should be displayed in the table
  - for each applicant, only course preferences for courses in the currently-selected round should appear under "Course Preferences"
- Summary view:
  - totals/stats should only be for applicants who applied to courses in the currently-selected round/assignments that were made to courses in the currently-selected round
  - only courses in the currently-selected round should be displayed in the table