### PR TITLE
[HotFix] Separate export chass route

### DIFF
--- a/app/controllers/download_controller.rb
+++ b/app/controllers/download_controller.rb
@@ -1,0 +1,27 @@
+class DownloadController < ApplicationController
+  protect_from_forgery with: :null_session
+
+  def chass
+    if params[:round_id]
+      file_path = "#{Rails.root}/db/exports/offers_#{params[:round_id]}.json"
+      File.open(file_path, "rb") do |f|
+        @data = f.read
+      end
+      File.delete(file_path)
+      render_helper({generated:true, data: @data, content_type: "application/json", file: "offers_#{params[:round_id]}.json"})
+    end
+  end
+
+  private
+  def render_helper(response)
+    if response[:generated]
+      send_data response[:data], filename: response[:file],
+      content_type: response[:type]
+    else
+      render status: 404, json: {
+        message: response[:msg]
+      }.to_json
+    end
+  end
+
+end

--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -1,24 +1,13 @@
 class ExportController < ApplicationController
   protect_from_forgery with: :null_session
 
-  def create_chass
+  def chass
     exporter = ChassExporter.new
     response = exporter.export(params[:round_id])
     if response[:generated]
       render status: 200, json: {message: response[:msg]}
     else
       render status: 404, json: {message: response[:msg]}
-    end
-  end
-
-  def download_chass
-    if params[:round_id]
-      file_path = "#{Rails.root}/db/exports/offers_#{params[:round_id]}.json"
-      File.open(file_path, "rb") do |f|
-        @data = f.read
-      end
-      File.delete(file_path)
-      render_helper({generated:true, data: @data, content_type: "application/json", file: "offers_#{params[:round_id]}.json"})
     end
   end
 

--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -4,7 +4,11 @@ class ExportController < ApplicationController
   def create_chass
     exporter = ChassExporter.new
     response = exporter.export(params[:round_id])
-    render json: response
+    if response[:generated]
+      render status: 200, json: {message: response[:msg]}
+    else
+      render status: 404, json: {message: response[:msg]}
+    end
   end
 
   def download_chass

--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -1,10 +1,21 @@
 class ExportController < ApplicationController
   protect_from_forgery with: :null_session
 
-  def chass
+  def create_chass
     exporter = ChassExporter.new
     response = exporter.export(params[:round_id])
-    render_helper(response)
+    render json: response
+  end
+
+  def download_chass
+    if params[:round_id]
+      file_path = "#{Rails.root}/db/exports/offers_#{params[:round_id]}.json"
+      File.open(file_path, "rb") do |f|
+        @data = f.read
+      end
+      File.delete(file_path)
+      render_helper({generated:true, data: @data, content_type: "application/json", file: "offers_#{params[:round_id]}.json"})
+    end
   end
 
   def cdf
@@ -28,7 +39,7 @@ class ExportController < ApplicationController
   private
   def render_helper(response)
     if response[:generated]
-      send_data response[:data], :filename => response[:file],
+      send_data response[:data], filename: response[:file],
       content_type: response[:type]
     else
       render status: 404, json: {

--- a/app/services/chass_exporter.rb
+++ b/app/services/chass_exporter.rb
@@ -20,7 +20,6 @@ class ChassExporter
 
     private
     def write_file(data, round_id)
-      puts "wr"
       File.open("#{Rails.root}/db/exports/offers_#{round_id}.json", "w+") do |f|
         puts data
         f.write(JSON.pretty_generate(data))

--- a/app/services/chass_exporter.rb
+++ b/app/services/chass_exporter.rb
@@ -11,7 +11,7 @@ class ChassExporter
           return {generated: false, msg: "Warning: You have not made any assignments. Operation aborted."}
         else
           write_file(create_data(round_id), round_id)
-          return {generated: true, msg: "Offers for #{round_id} has been generated.", round_id: round_id}
+          return {generated: true, msg: "Offers for #{round_id} has been generated."}
         end
       else
         return {generated: false, msg: "Error: Invalid round_id"}

--- a/app/services/chass_exporter.rb
+++ b/app/services/chass_exporter.rb
@@ -21,7 +21,6 @@ class ChassExporter
     private
     def write_file(data, round_id)
       File.open("#{Rails.root}/db/exports/offers_#{round_id}.json", "w+") do |f|
-        puts data
         f.write(JSON.pretty_generate(data))
       end
     end

--- a/app/services/chass_exporter.rb
+++ b/app/services/chass_exporter.rb
@@ -10,9 +10,8 @@ class ChassExporter
         if @assignments.size == 0
           return {generated: false, msg: "Warning: You have not made any assignments. Operation aborted."}
         else
-          data = create_data(round_id)
-          return {generated: true, data: JSON.pretty_generate(data),
-            file: "offers_#{round_id}.json", type: "application/json"}
+          write_file(create_data(round_id), round_id)
+          return {generated: true, msg: "Offers for #{round_id} has been generated.", round_id: round_id}
         end
       else
         return {generated: false, msg: "Error: Invalid round_id"}
@@ -20,6 +19,14 @@ class ChassExporter
     end
 
     private
+    def write_file(data, round_id)
+      puts "wr"
+      File.open("#{Rails.root}/db/exports/offers_#{round_id}.json", "w+") do |f|
+        puts data
+        f.write(JSON.pretty_generate(data))
+      end
+    end
+
     def is_valid_round_id(round_id)
       @positions = Position.all
       valid = false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,8 @@ Rails.application.routes.draw do
 
   get "/index.html/(*z)", to: "app#main"
 
-  get "/export/chass/:round_id", to: "export#chass"
+  post "/export/chass/:round_id", to: "export#create_chass"
+  get "/download/chass/:round_id", to: "export#download_chass"
   get "/export/cdf-info", to: "export#cdf"
   get "/export/transcript-access", to: "export#transcript_access"
   get "/export/offers", to: "export#offers"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,8 +13,8 @@ Rails.application.routes.draw do
 
   get "/index.html/(*z)", to: "app#main"
 
-  post "/export/chass/:round_id", to: "export#create_chass"
-  get "/download/chass/:round_id", to: "export#download_chass"
+  post "/export/chass/:round_id", to: "export#chass"
+  get "/download/chass/:round_id", to: "download#chass"
   get "/export/cdf-info", to: "export#cdf"
   get "/export/transcript-access", to: "export#transcript_access"
   get "/export/offers", to: "export#offers"

--- a/spec/controllers/export_controller_spec.rb
+++ b/spec/controllers/export_controller_spec.rb
@@ -138,9 +138,8 @@ RSpec.describe ExportController, type: :controller do
           it "returns status 200 and downloads offers_(round_id).json" do
             get :chass, params: {round_id: position[:round_id]}
             expect(response.status).to eq(200)
-            expect(response.content_type).to eq("application/json")
-            expect(response.header["Content-Disposition"]).to eq(
-              "attachment; filename=\"offers_110.json\"")
+            message = {message: "Offers for #{position[:round_id]} has been generated."}
+            expect(response.body).to eq(message.to_json)
           end
 
         end

--- a/spec/services/chass_exporter_spec.rb
+++ b/spec/services/chass_exporter_spec.rb
@@ -90,8 +90,7 @@ describe ChassExporter do
       subject { exporter.export(position[:round_id]) }
 
       it "returns generated true and data of all assignments in :round_id" do
-        expect(subject).to eq ({generated: true, data: JSON.pretty_generate(@data),
-          type: "application/json", file: "offers_#{position[:round_id]}.json"})
+        expect(subject).to eq ({generated: true, msg: "Offers for #{position[:round_id]} has been generated."})
       end
     end
 


### PR DESCRIPTION
Fix for downloading JSON has been found with original route
---------

- as described in title
- the 2 routes are:
  - `POST /export/chass/:round_id`
    - return status 200 with a message if success
    - returns status 404 with a message if failed
  - `GET /download/chass/:round_id` 
    - this path assumes that you will only download this file once. The file is deleted immediately after it's sent. You have to call the first route again to make this route work.
- fixed specs accordingly
- below is a diagram of how the routes should work
![img_20170811_121609](https://user-images.githubusercontent.com/22383586/29222095-1bd6d578-7e8f-11e7-8d86-da7ae9a1b79d.jpg)
