### PR TITLE
Fix applicant table column header alignment

### DIFF
--- a/app/assets/stylesheets/app.css
+++ b/app/assets/stylesheets/app.css
@@ -244,6 +244,11 @@ footer div p {
     margin: 0;
 }
 
+.table-container td,
+.table-container th {
+    word-break: break-all;
+}
+
 .highlightOnHover:hover {
     font-weight: bold;
     cursor: pointer;

--- a/app/javascript/app/components/applicantTable.js
+++ b/app/javascript/app/components/applicantTable.js
@@ -6,7 +6,15 @@ const THeader = props =>
     <thead>
         <tr>
             {props.config.map((field, i) =>
-                <th key={'header-' + i} style={field.style ? field.style() : {}}>
+                <th
+                    key={'header-' + i}
+                    style={
+                        field.style
+                            ? Object.assign({}, field.style, {
+                                  width: 'calc(' + field.style.width + '*100vw)',
+                              })
+                            : {}
+                    }>
                     {field.header}
                 </th>
             )}
@@ -18,7 +26,13 @@ const ApplicantRow = props =>
         {props.config.map((field, i) =>
             <td
                 key={'applicant-' + props.applicantId + '-row-' + i}
-                style={field.style ? field.style() : {}}>
+                style={
+                    field.style
+                        ? Object.assign({}, field.style, {
+                              width: 'calc(' + field.style.width + '*100vw)',
+                          })
+                        : {}
+                }>
                 {field.data(props)}
             </td>
         )}
@@ -148,7 +162,10 @@ ApplicantTable.propTypes = {
             filterFuncs: PropTypes.arrayOf(PropTypes.func),
 
             // style applied to cells in table column
-            style: PropTypes.func,
+            style: PropTypes.shape({
+                // column width - this should be a number between 0 and 1
+                width: PropTypes.number,
+            }),
         })
     ).isRequired,
 

--- a/app/javascript/app/components/assigned.js
+++ b/app/javascript/app/components/assigned.js
@@ -28,14 +28,14 @@ class Assigned extends React.Component {
                     </span>,
                 sortData: p => p.applicant.lastName,
 
-                style: () => ({ width: '10%' }),
+                style: { width: 0.10 },
             },
             {
                 header: 'First Name',
                 data: p => p.applicant.firstName,
                 sortData: p => p.applicant.firstName,
 
-                style: () => ({ width: '10%' }),
+                style: { width: 0.10 },
             },
             {
                 header: 'Dept.',
@@ -49,7 +49,7 @@ class Assigned extends React.Component {
                     p => p.applicant.dept != 'Computer Science',
                 ],
 
-                style: () => ({ width: '13%' }),
+                style: { width: 0.08 },
             },
             {
                 header: 'Prog.',
@@ -65,21 +65,21 @@ class Assigned extends React.Component {
                     p => p.applicant.program == 'UG',
                 ],
 
-                style: () => ({ width: '5%' }),
+                style: { width: 0.05 },
             },
             {
                 header: 'Year',
                 data: p => p.applicant.year,
                 sortData: p => p.applicant.year,
 
-                style: () => ({ width: '2%' }),
+                style: { width: 0.03 },
             },
             {
                 header: 'Email',
                 data: p => p.applicant.email,
                 sortData: p => p.applicant.email,
 
-                style: () => ({ width: '20%' }),
+                style: { width: 0.20 },
             },
             {
                 header: 'Course(s)',

--- a/app/javascript/app/components/coursePanel.js
+++ b/app/javascript/app/components/coursePanel.js
@@ -55,7 +55,7 @@ class CoursePanel extends React.Component {
                     }
                 },
 
-                style: () => ({ width: '2%', textAlign: 'center' }),
+                style: { width: 0.02, textAlign: 'center' },
             },
             {
                 header: 'Last Name',
@@ -70,14 +70,14 @@ class CoursePanel extends React.Component {
                     </span>,
                 sortData: p => p.applicant.lastName,
 
-                style: () => ({ width: '15%' }),
+                style: { width: 0.15 },
             },
             {
                 header: 'First Name',
                 data: p => p.applicant.firstName,
                 sortData: p => p.applicant.firstName,
 
-                style: () => ({ width: '15%' }),
+                style: { width: 0.15 },
             },
             {
                 header: 'Dept.',
@@ -91,7 +91,7 @@ class CoursePanel extends React.Component {
                     p => p.applicant.dept != 'Computer Science',
                 ],
 
-                style: () => ({ width: '25%' }),
+                style: { width: 0.25 },
             },
             {
                 header: 'Prog.',
@@ -108,14 +108,14 @@ class CoursePanel extends React.Component {
                     p => p.applicant.program == 'UG',
                 ],
 
-                style: () => ({ width: '10%' }),
+                style: { width: 0.10 },
             },
             {
                 header: 'Year',
                 data: p => p.applicant.year,
                 sortData: p => p.applicant.year,
 
-                style: () => ({ width: '5%' }),
+                style: { width: 0.05 },
             },
             {
                 header: 'Pref.',
@@ -127,7 +127,7 @@ class CoursePanel extends React.Component {
 
                 sortData: p => props.getApplicationPreference(p.applicantId, p.course),
 
-                style: () => ({ width: '5%' }),
+                style: { width: 0.05 },
             },
             {
                 header: 'Other',
@@ -164,8 +164,6 @@ class CoursePanel extends React.Component {
                     // filter corresponding to 'unassigned'
                     p => props.getAssignmentsByApplicant(p.applicantId).length == 0,
                 ],
-
-                style: () => ({}),
             },
         ];
     }

--- a/app/javascript/app/components/unassigned.js
+++ b/app/javascript/app/components/unassigned.js
@@ -28,14 +28,14 @@ class Unassigned extends React.Component {
                     </span>,
                 sortData: p => p.applicant.lastName,
 
-                style: () => ({ width: '10%' }),
+                style: { width: 0.10 },
             },
             {
                 header: 'First Name',
                 data: p => p.applicant.firstName,
                 sortData: p => p.applicant.firstName,
 
-                style: () => ({ width: '10%' }),
+                style: { width: 0.10 },
             },
             {
                 header: 'Dept.',
@@ -49,7 +49,7 @@ class Unassigned extends React.Component {
                     p => p.applicant.dept != 'Computer Science',
                 ],
 
-                style: () => ({ width: '13%' }),
+                style: { width: 0.08 },
             },
             {
                 header: 'Prog.',
@@ -65,21 +65,21 @@ class Unassigned extends React.Component {
                     p => p.applicant.program == 'UG',
                 ],
 
-                style: () => ({ width: '5%' }),
+                style: { width: 0.05 },
             },
             {
                 header: 'Year',
                 data: p => p.applicant.year,
                 sortData: p => p.applicant.year,
 
-                style: () => ({ width: '2%' }),
+                style: { width: 0.03 },
             },
             {
                 header: 'Email',
                 data: p => p.applicant.email,
                 sortData: p => p.applicant.email,
 
-                style: () => ({ width: '20%' }),
+                style: { width: 0.20 },
             },
             {
                 header: 'Course Preferences',


### PR DESCRIPTION
In the applicant tables (abc/assigned/unassigned views), the column headers should now be aligned with the columns, even when the table is resized (by resizing the browser window).