### PR TITLE
[hotfix] fix bug for importing HLP courses

### DIFF
--- a/app/services/chass_importer.rb
+++ b/app/services/chass_importer.rb
@@ -213,12 +213,10 @@ class ChassImporter
 
   def insert_positions
     @course_data.each do |course_entry|
-      puts course_entry["course_id"]
       posting_id  = course_entry["course_id"]
       course_id = posting_id.split("-")[0].strip
       round_id = course_entry["round_id"]
       session_id = get_session_id(course_entry["dates"])
-      puts "hello: #{session_id}"
       if session_id
         exists = "Position #{posting_id} already exists"
         ident = {position: posting_id, round_id: round_id}
@@ -236,7 +234,6 @@ class ChassImporter
           estimated_total_hours: course_entry["total_hours"],
           session_id: session_id,
         }
-        puts data
         position = insertion_helper(Position, data, ident, exists)
 
         teaching_instructors = []

--- a/app/services/chass_importer.rb
+++ b/app/services/chass_importer.rb
@@ -213,10 +213,12 @@ class ChassImporter
 
   def insert_positions
     @course_data.each do |course_entry|
+      puts course_entry["course_id"]
       posting_id  = course_entry["course_id"]
       course_id = posting_id.split("-")[0].strip
       round_id = course_entry["round_id"]
       session_id = get_session_id(course_entry["dates"])
+      puts "hello: #{session_id}"
       if session_id
         exists = "Position #{posting_id} already exists"
         ident = {position: posting_id, round_id: round_id}
@@ -234,6 +236,7 @@ class ChassImporter
           estimated_total_hours: course_entry["total_hours"],
           session_id: session_id,
         }
+        puts data
         position = insertion_helper(Position, data, ident, exists)
 
         teaching_instructors = []
@@ -279,7 +282,19 @@ class ChassImporter
         session = insertion_helper(Session, data, ident, exists)
         return session.id
       else
-        return nil
+        dates = dates[0].split(" - ")
+        start_date = DateTime.parse(dates[0])
+        end_date =  DateTime.parse(dates[1])
+        data ={
+          start_date: start_date,
+          end_date: end_date,
+          year: start_date.strftime("%Y"),
+          semester: get_semester(start_date),
+        }
+        exists = "Session #{data[:semester]}, #{data[:year]} already exists"
+        ident = {year: data[:year], semester: data[:semester]}
+        session = insertion_helper(Session, data, ident, exists)
+        return session.id
       end
     else
       return nil

--- a/db/seeds/hlp_bug_test.json
+++ b/db/seeds/hlp_bug_test.json
@@ -1,0 +1,43 @@
+{
+    "courses": [
+        {
+            "instructor": [],
+            "last_updated": "2017-07-06 10:47:43",
+            "end_nominations": null,
+            "status": "1",
+            "end_posting": null,
+            "start_posting": null,
+            "total_hours": "0",
+            "duties": "Hold office hours on a weekly basis to assist students taking 100-level CSC courses. ",
+            "qualifications": "Must be enrolled in or have completed a computer science degree, or equivalent. Must meet the qualifications to TA *ALL* of CSC 108, 148, and 165 (see CSC108H1F-B, CSC148H1F, CSC165H1F qualifications). Enthusiasm and patience for face-to-face teaching of beginners is required. Experience with CSC 104 or Racket preferred.",
+            "tutorials": "",
+            "dates": "September 7 - December 31",
+            "n_hours": "60",
+            "n_positions": "6",
+            "enrollment": "N/A",
+            "round_id": "110",
+            "course_name": "Help Centre for First Year courses",
+            "course_id": "HLP101H-First"
+        },
+        {
+            "instructor": [],
+            "last_updated": "2017-07-06 10:47:43",
+            "end_nominations": null,
+            "status": "1",
+            "end_posting": null,
+            "start_posting": null,
+            "total_hours": "0",
+            "duties": "Staff a Help Centre for undergraduate students, providing help to students on a drop-in basis. Maintain some familiarity with the current assignments in key courses. Each Help Centre TA will focus on one of the following areas: first-year (csc108, 148, and 165), theory courses (primarily 373), programming courses (primarily 209). Other related duties as required. ",
+            "qualifications": "TA experience in CS courses at UofT, evidence of excellent teaching skills, enthusiasm for teaching beginners, strong background in the relevant focus area (see Responsibilities), excellent communication skills in English (verbal and in writing), excellent interpersonal skills. As well as filling in the online application, applicants must submit additional information by email.  Work in the Help Centre will take place in the late afternoon to early evening, Mondays to Thursdays. There will be flexibility for picking times within that range, but applicants should generally be available at that time of day/week. \r\n\r\nApplication process: In addition to filling out the regular application form, email helpcentreta@cs.toronto.edu to arrange an interview with the Associate Chair, Francois Pitt. Include the following information in your email: evidence of satisfying each of the requirements above, and the name of at least one reference who can comment on your teaching ability.",
+            "tutorials": "",
+            "dates": "September 7 - December 31",
+            "n_hours": "60",
+            "n_positions": "6",
+            "enrollment": "N/A",
+            "round_id": "110",
+            "course_name": "Help Centre TA",
+            "course_id": "HLP101H1"
+        }
+    ],
+    "applicants": []
+}


### PR DESCRIPTION
- issue raised in #175 
- Cause:
  - the `dates` attributes in HLP courses in the CHASS JSON has a different format than other course
    - HLP: `month day - month day`
    - other courses: `month day, year to month day, year`
  - this created an error with parsing the dates and creating a sessions model.
  - without a `Session` model, the `Position` model, which was dependent on it, was not created