### PR TITLE
docker-compose network cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,5 +36,4 @@ RUN if [ ${RAILS_ENV} = 'production' ]; then \
 bundle exec rake webpacker:compile; \
 fi
 
-EXPOSE 3000
 CMD ["rails", "server", "-b", "0.0.0.0", "-p", "3000"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -10,8 +10,6 @@ services:
     build: .
     volumes:
       - .:/srv/app
-    networks:
-      - internal
     ports:
       - "8080:8080"
     command: >

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       SECRET_KEY_BASE: ${SECRET_KEY_BASE}
     networks:
       - default
-      - front_end
+      - frontend
     ports:
       - "3000:3000"
     links:
@@ -30,6 +30,6 @@ services:
       - /var/lib/postgresql/data
 
 networks:
-  # "front_end" network will be attached to CP app so it can use the endpoints
-  front_end:
+  # "frontend" network will be attached to CP app so it can use the endpoints
+  frontend:
     driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,8 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       SECRET_KEY_BASE: ${SECRET_KEY_BASE}
     networks:
-      - internal
-      - external
+      - default
+      - front_end
     ports:
       - "3000:3000"
     links:
@@ -28,12 +28,8 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     volumes:
       - /var/lib/postgresql/data
-    networks:
-      - internal
 
 networks:
-  # Names of the networks will be prefixed with project name by docker
-  internal:
-    driver: bridge
-  external:
+  # "front_end" network will be attached to CP app so it can use the endpoints
+  front_end:
     driver: bridge


### PR DESCRIPTION
remove the internal network -- it's redundant.
While at it, change the name of the network on which the endpoint is exposed to tapp_frontend
(following examples in compose manual)

NB, this will break cp unless the corresponding name change is landed in that  repo as in CP PR17