### PR TITLE
[hotfix] make enrollment attributes updateable

### DIFF
--- a/app/controllers/positions_controller.rb
+++ b/app/controllers/positions_controller.rb
@@ -22,7 +22,7 @@ class PositionsController < ApplicationController
   private
   def position_params
     params.permit(:duties, :qualifications, :hours, :estimated_count,
-      :estimated_total_hours, :open, :estimated_enrolment)
+      :estimated_total_hours, :open, :current_enrollment, :cap_enrollment, :num_waitlisted)
   end
 
 end


### PR DESCRIPTION
This is an issue noticed by @gabriellesc. 
- `current_enrollment`, `cap_enrollment`, and `num_waitlisted` wasn't update-able in the PR #179 
This PR makes the above attributes update-able by routes